### PR TITLE
backup does not depend on sqlite3-ruby. 

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -45,7 +45,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency('net-scp',       [">= 1.0.2"])
   gem.add_dependency('net-sftp',      [">= 2.0.4"])
   gem.add_dependency('activerecord',  [">= 2.3.5"])
-  gem.add_dependency('sqlite3-ruby',  [">= 1.2.5"])
   gem.add_dependency('hirb',          [">= 0.2.9"])
   gem.add_dependency('pony',          [">= 0.5"])
   gem.add_dependency('cloudfiles',    [">= 1.4.7"])


### PR DESCRIPTION
This dependency is not needed and it was forcing me to install that gem on my server, which I don't need at all.
