### PR TITLE
Error notification emails

### DIFF
--- a/lib/backup/adapters/base.rb
+++ b/lib/backup/adapters/base.rb
@@ -57,6 +57,8 @@ module Backup
           handle_after_backup
           record
           notify
+	rescue => ex
+	  notify ex
         ensure
           remove_tmp_files
         end
@@ -140,10 +142,10 @@ module Backup
         record.save
       end
       
-      # Delivers a notification by email regarding the successfully stored backup
-      def notify
+      # Delivers a notification by email regarding the result of the backup attempt
+      def notify(exception = nil)
         if Backup::Mail::Base.setup?
-          Backup::Mail::Base.notify!(self)
+          Backup::Mail::Base.notify!(self, exception)
         end
       end
       

--- a/lib/backup/mail/error.txt
+++ b/lib/backup/mail/error.txt
@@ -1,0 +1,5 @@
+A backup failed for the trigger: ":trigger"! on ":day of :month :year at :time", using the ":adapter" adapter.
+
+The error was as follows:
+:exception
+


### PR DESCRIPTION
Hi there,

I added a feature so that an email notification will be sent when the backup errors out if the 'notify' config setting is set to to true or :only_errors.  I think it would be useful to other people, and it's a must-have for our scenario, so it would be awesome if you pulled in this change and I could switch back to the main fork!

Thanks,
Pat Gannon
PatrickJosephGannon@yahoo.com
@patgannon
