### PR TITLE
Patch tar call

### DIFF
--- a/lib/backup/archive.rb
+++ b/lib/backup/archive.rb
@@ -49,7 +49,7 @@ module Backup
     def perform!
       mkdir(archive_path)
       Logger.message("#{ self.class } started packaging and archiving #{ paths.map { |path| "\"#{path}\""}.join(", ") }.")
-      run("#{ utility(:tar) } -c #{ paths_to_exclude } #{ paths_to_package } 1> '#{ File.join(archive_path, "#{name}.tar") }' 2> /dev/null")
+      run("#{ utility(:tar) } -c -f #{ File.join(archive_path, "#{name}.tar") } #{ paths_to_exclude } #{ paths_to_package } 2> /dev/null")
     end
 
   private


### PR DESCRIPTION
Hello Michael!

I changed only one line in your "archive.rb", cause it rose an error on my FreeBSD machines. The installed "tar"-utility (which is distributed with the base system) has a nasty default for output:

(look at the "-f" parameter)

<pre>
[root@www1 ~]# tar --help
tar(bsdtar): manipulate archive files
First option must be a mode specifier:
  -c Create  -r Add/Replace  -t List  -u Update  -x Extract
Common Options:
  -b #  Use # 512-byte records per I/O block
  -f <filename>  Location of archive (default /dev/sa0)
  -v    Verbose
  -w    Interactive
(...)
bsdtar 2.7.0 - libarchive 2.7.0
</pre>


The correspondenting error:

<pre>
[root@www1 ~]# tar -c . 1> bla.tar
tar: Failed to open '/dev/sa0'
[root@www1 ~]# tar -c -f bla.tar .          
[root@www1 ~]# 
</pre>


Hope this finds the way back in your nice piece of software.

Kind regards, Stefan
