### PR TITLE
Add a "--quiet" or "-q" option to perform

### DIFF
--- a/bin/backup
+++ b/bin/backup
@@ -31,11 +31,12 @@ class BackupCLI < Thor
   # Performs the backup process. The only required option is the --trigger [-t].
   # If the other options (--config_file, --data_path, --tmp_path) aren't specified
   # it'll fallback to the (good) defaults
-  method_option :trigger,     :type => :string, :aliases => ['-t', '--triggers'], :required => true
-  method_option :config_file, :type => :string, :aliases => '-c'
-  method_option :data_path,   :type => :string, :aliases => '-d'
-  method_option :log_path,    :type => :string, :aliases => '-l'
+  method_option :trigger,     :type => :string,  :aliases => ['-t', '--triggers'], :required => true
+  method_option :config_file, :type => :string,  :aliases => '-c'
+  method_option :data_path,   :type => :string,  :aliases => '-d'
+  method_option :log_path,    :type => :string,  :aliases => '-l'
   method_option :tmp_path,    :type => :string
+  method_option :quiet,       :type => :boolean, :aliases => '-q'
   desc 'perform', "Performs the backup for the specified trigger.\n" + 
                   "You may perform multiple backups by providing multiple triggers, separated by commas.\n\n" +
                   "Example:\n\s\s$ backup perform --triggers backup1,backup2,backup3,backup4\n\n" +
@@ -74,6 +75,12 @@ class BackupCLI < Thor
     # Ensure the TMP_PATH and LOG_PATH are created if they do not yet exist
     Array.new([Backup::TMP_PATH, Backup::LOG_PATH]).each do |path|
       FileUtils.mkdir_p(path)
+    end
+
+    ##
+    # Silence Backup::Logger from printing to STDOUT, if --quiet was specified
+    if options[:quiet]
+      Backup::Logger.send(:const_set, :QUIET, options[:quiet])
     end
 
     ##

--- a/lib/backup/logger.rb
+++ b/lib/backup/logger.rb
@@ -6,21 +6,21 @@ module Backup
     ##
     # Outputs a messages to the console and writes it to the backup.log
     def self.message(string)
-      puts    loggify(:message, string, :green)
+      puts    loggify(:message, string, :green) unless quiet?
       to_file loggify(:message, string)
     end
 
     ##
     # Outputs an error to the console and writes it to the backup.log
     def self.error(string)
-      puts    loggify(:error, string, :red)
+      puts    loggify(:error, string, :red) unless quiet?
       to_file loggify(:error, string)
     end
 
     ##
     # Outputs a notice to the console and writes it to the backup.log
     def self.warn(string)
-      puts    loggify(:warning, string, :yellow)
+      puts    loggify(:warning, string, :yellow) unless quiet?
       to_file loggify(:warning, string)
     end
 
@@ -28,7 +28,7 @@ module Backup
     # Outputs the data as if it were a regular 'puts' command,
     # but also logs it to the backup.log
     def self.normal(string)
-      puts    string
+      puts    string unless quiet?
       to_file string
     end
 
@@ -88,6 +88,10 @@ module Backup
     # easier to view output to the client
     def self.colorize(string, code)
       "\e[#{code}m#{string}\e[0m"
+    end
+
+    def self.quiet?
+      const_defined?(:QUIET) && QUIET
     end
 
   end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -43,4 +43,16 @@ describe Backup::Logger do
       Backup::Logger.silent "This has been logged."
     end
   end
+
+  context 'when quieted' do
+    it do
+      Backup::Logger.send(:const_set, :QUIET, true)
+      Backup::Logger.expects(:puts).never
+
+      Backup::Logger.message "This has been logged."
+      Backup::Logger.error   "This has been logged."
+      Backup::Logger.warn    "This has been logged."
+      Backup::Logger.normal  "This has been logged."
+    end
+  end
 end


### PR DESCRIPTION
Silences STDOUT output from Backup::Logger

It wasn't clear to me how you go about testing `bin/backup`, so I haven't done anything with that beyond making sure the option shows up in help output.

Written to fix #101
