### PR TITLE
'safe' option for mongo backups that wraps mongodump: fsync&lock before m

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ The __Mail__ notifier. I have not provided the SMTP options to use my Gmail acco
 
 The __Twitter__ notifier. You will require your consumer and oauth credentials, which I have also left out of this example.
 
+MongoDB backup utility (mongodump) by default does not fsync & lock the database, opening a possibility for inconsistent data dump. This is addressed by setting safe = true which causes mongodump to be wrapped with lock&fsync calls (with a lock takedown after the dump). Please check the Wiki on this subject and remember this is a very fresh feature, needing some more real-world testing. 
+
 Check out the Wiki for more information on all the above subjects.
 
 ### And that's it!


### PR DESCRIPTION
'safe' option for mongo backups that wraps mongodump: fsync&lock before mongodump, unlock after mongodump.

as discussed in issue #107.

and yes, my eyes also hurt when looking at this code. but it works. but should be marked as beta and in need for more tests (especially in scenarios when mongodump exits with error).
