### PR TITLE
mongodump does not have a --port parameter

### DIFF
--- a/lib/backup/database/mongodb.rb
+++ b/lib/backup/database/mongodb.rb
@@ -55,10 +55,8 @@ module Backup
       # Builds the MongoDB connectivity options syntax to connect the user
       # to perform the database dumping process
       def connectivity_options
-        %w[host port].map do |option|
-          next if send(option).nil? or (send(option).respond_to?(:empty?) and send(option).empty?)
-          "--#{option}='#{send(option)}'"
-        end.compact.join("\s")
+        h = host.to_s.empty? ? 'localhost' : host
+        "--host='#{h}#{ port ? ":"+port.to_s : ''}'"
       end
 
       ##

--- a/spec/database/mongodb_spec.rb
+++ b/spec/database/mongodb_spec.rb
@@ -13,7 +13,7 @@ describe Backup::Database::MongoDB do
       db.name      = 'mydatabase'
       db.username  = 'someuser'
       db.password  = 'secret'
-      db.host      = 'localhost'
+      db.host      = 'examplehost.com'
       db.port      = 123
 
       db.ipv6               = true
@@ -27,7 +27,7 @@ describe Backup::Database::MongoDB do
       db.name.should      == 'mydatabase'
       db.username.should  == 'someuser'
       db.password.should  == 'secret'
-      db.host.should      == 'localhost'
+      db.host.should      == 'examplehost.com'
       db.port.should      == 123
 
       db.only_collections.should == ['users', 'pirates']
@@ -73,7 +73,7 @@ describe Backup::Database::MongoDB do
 
   describe '#connectivity_options' do
     it 'should return the mongo syntax for the connectivity options' do
-      db.connectivity_options.should == "--host='localhost' --port='123'"
+      db.connectivity_options.should == "--host='examplehost.com:123'"
     end
 
     it 'should return only the socket' do
@@ -82,7 +82,7 @@ describe Backup::Database::MongoDB do
         db.port   = 123
       end
 
-      db.connectivity_options.should == "--port='123'"
+      db.connectivity_options.should == "--host='localhost:123'"
     end
   end
 
@@ -103,7 +103,7 @@ describe Backup::Database::MongoDB do
       db.expects(:utility).with(:mongodump).returns('mongodump')
       db.mongodump.should ==
       "mongodump --db='mydatabase' --username='someuser' --password='secret' " +
-      "--host='localhost' --port='123' --ipv6 --query --out='#{ File.join(Backup::TMP_PATH, Backup::TRIGGER, 'MongoDB') }'"
+      "--host='examplehost.com:123' --ipv6 --query --out='#{ File.join(Backup::TMP_PATH, Backup::TRIGGER, 'MongoDB') }'"
     end
   end
 


### PR DESCRIPTION
mongodump does not have a --port argument 
See:
http://www.mongodb.org/display/DOCS/Import+Export+Tools#ImportExportTools-mongodump

I'm currently working around this issue by passing the port into the host param:
db.host    = "somehost.com:27091"

One side effect of this patch is that the host argument always gets a value. If no host is set the param is --host='localhost'

I'm not sure if there is anything wrong with that but I thought I should be upfront about this change.
