### PR TITLE
fixed Archive exclude to work in more environments

### DIFF
--- a/lib/backup/archive.rb
+++ b/lib/backup/archive.rb
@@ -66,7 +66,7 @@ module Backup
     # Returns a "tar-ready" string of all the specified excludes combined
     def paths_to_exclude
       if excludes.any?
-        "--exclude={" + excludes.map{ |e| "'#{e}'" }.join(",") + "}"
+        excludes.map{ |e| "--exclude='#{e}'" }.join(" ")
       end
     end
   end

--- a/spec/archive_spec.rb
+++ b/spec/archive_spec.rb
@@ -9,8 +9,8 @@ describe Backup::Archive do
       a.add '/home/rspecuser/somefile'
       a.add '/home/rspecuser/logs/'
       a.add '/home/rspecuser/dotfiles/'
-      a.exclude '/home/rspecuser/excludefile'
-      a.exclude '/home/rspecuser/excludedir/'
+      a.exclude '/home/rspecuser/badfile'
+      a.exclude '/home/rspecuser/wrongdir/'
     end
   end
 
@@ -51,7 +51,7 @@ describe Backup::Archive do
 
     it 'should return a tar -c friendly string' do
       archive.send(:paths_to_exclude).should ==
-      "--exclude={'/home/rspecuser/excludefile','/home/rspecuser/excludedir/'}"
+      "--exclude='/home/rspecuser/badfile' --exclude='/home/rspecuser/wrongdir/'"
     end
   end
 
@@ -64,7 +64,7 @@ describe Backup::Archive do
     context 'when both paths were added and paths that should be excluded were added' do
       it 'should render both the syntax for the paths that be included as well as excluded' do
         archive.expects(:mkdir).with(File.join(Backup::TMP_PATH, Backup::TRIGGER, 'archive'))
-        archive.expects(:run).with("tar -c -f '#{File.join(Backup::TMP_PATH, Backup::TRIGGER, 'archive', "#{:dummy_archive}.tar")}' --exclude={'/home/rspecuser/excludefile','/home/rspecuser/excludedir/'} '/home/rspecuser/somefile' '/home/rspecuser/logs/' '/home/rspecuser/dotfiles/' 2> /dev/null")
+        archive.expects(:run).with("tar -c -f '#{File.join(Backup::TMP_PATH, Backup::TRIGGER, 'archive', "#{:dummy_archive}.tar")}' --exclude='/home/rspecuser/badfile' --exclude='/home/rspecuser/wrongdir/' '/home/rspecuser/somefile' '/home/rspecuser/logs/' '/home/rspecuser/dotfiles/' 2> /dev/null")
         archive.expects(:utility).with(:tar).returns(:tar)
         archive.perform!
       end


### PR DESCRIPTION
I found problem with Archive#exclude on Ubuntu 10.04. In my environment it just ignored these definitions. So I've modified syntax to use multiple --exclude definitions instead. Spec modified too.

Tested on Ubuntu 10.04 and Mac OS X 10.6.
GNU tar 1.22
bsdtar 2.6.2
