### PR TITLE
Support require with relative path within Backup config files

### DIFF
--- a/lib/backup/finder.rb
+++ b/lib/backup/finder.rb
@@ -22,7 +22,7 @@ module Backup
 
       ##
       # Loads the backup configuration file
-      instance_eval(File.read(config))
+      instance_eval(File.read(config), config, 1)
 
       ##
       # Iterates through all the instantiated backup models and returns


### PR DESCRIPTION
Without giving the second and third args, string-based `instance_eval` doesn't provide valid `__FILE__` and `__LINE__` references within the backup config file.

Useful for building a relative path, among other things.

I totally stole this from the Bundler method for evaluating `Gemfiles` (`Bundler::Dsl.evaluate`).
