### PR TITLE
Local Rsync Backups

### DIFF
--- a/lib/backup/storage/rsync.rb
+++ b/lib/backup/storage/rsync.rb
@@ -78,7 +78,7 @@ module Backup
         Logger.message("#{ self.class } started transferring \"#{ remote_file }\".")
         create_remote_directories!
         if @local
-          run("#{ utility(:rsync) } #{ options } #{ password } '#{ File.join(local_path, local_file) }' '#{ File.join(remote_path, TIME+'.'+remote_file[20..-1]) }'")
+          run("#{ utility(:rsync) } '#{ File.join(local_path, local_file) }' '#{ File.join(remote_path, TIME+'.'+remote_file[20..-1]) }'")
         else
           run("#{ utility(:rsync) } #{ options } #{ password } '#{ File.join(local_path, local_file) }' '#{ username }@#{ ip }:#{ File.join(remote_path, remote_file[20..-1]) }'")
         end

--- a/spec/configuration/storage/rsync_spec.rb
+++ b/spec/configuration/storage/rsync_spec.rb
@@ -20,6 +20,7 @@ describe Backup::Configuration::Storage::RSync do
     rsync.ip.should       == '123.45.678.90'
     rsync.port.should     == 21
     rsync.path.should     == 'my_backups'
+    rsync.local.should    == false
   end
 
   describe '#clear_defaults!' do
@@ -32,6 +33,7 @@ describe Backup::Configuration::Storage::RSync do
       rsync.ip.should       == nil
       rsync.port.should     == nil
       rsync.path.should     == nil
+      rsync.local.should    == nil
     end
   end
 end

--- a/spec/storage/rsync_spec.rb
+++ b/spec/storage/rsync_spec.rb
@@ -52,6 +52,7 @@ describe Backup::Storage::RSync do
     rsync = Backup::Storage::RSync.new
     rsync.port.should == 22
     rsync.path.should == 'backups'
+    rsync.local.should == false
   end
 
   describe '#connection' do
@@ -127,5 +128,14 @@ describe Backup::Storage::RSync do
       rsync.perform!
     end
   end
-
+  
+  describe '#local backups' do
+    it 'should save a local copy of backups' do
+      rsync.local = true
+      rsync.expects(:utility).returns('rsync')
+      rsync.expects(:run).with("rsync '#{ File.join(Backup::TMP_PATH, "#{ Backup::TIME }.#{ Backup::TRIGGER }.tar") }' 'backups/#{ Backup::TRIGGER }/#{ Backup::TIME }.#{ Backup::TRIGGER }.tar'")
+      rsync.send(:transfer!)
+    end
+  end
+  
 end


### PR DESCRIPTION
Hey Guys,

OK. So I ended up rewriting the "local backups" code and moving it into the Rsync storage class. Things seem to be working well on OSX and our CentOS servers. I also did my best to update the spec tests accordingly, although it might be worth glancing over my changes.

If this pull request gets accepted, I'll add the information into the Wiki.

I think the result is quite graceful:

```
Backup::Model.new(:example, 'Example') do

  # 
  # ##
  # # RSync [Storage]
  # #
  store_with RSync do |server|
    server.local    = true 
    server.path     = '/path/to/local/backups/'
  end

end
```

Let me know if you have any questions or problems. If accepted, this will be my first Github pull request, so I'm sorry if anything is out of sorts.
