### PR TITLE
Store GPG keys more securely.

### DIFF
--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -2,6 +2,7 @@
 
 require 'fileutils'
 require 'yaml'
+require 'etc'
 
 ##
 # The Backup Ruby Gem
@@ -37,6 +38,7 @@ module Backup
 
   ##
   # Backup's Environment paths
+  USER               = ENV['USER'] || Etc.getpwuid.name # The user the backup is running as.
   PATH               = File.join(ENV['HOME'], 'Backup')
   DATA_PATH          = File.join(ENV['HOME'], 'Backup', 'data')
   CONFIG_FILE        = File.join(ENV['HOME'], 'Backup', 'config.rb')

--- a/lib/backup/encryptor/gpg.rb
+++ b/lib/backup/encryptor/gpg.rb
@@ -62,6 +62,8 @@ module Backup
       # Creates a new temp file and writes the provided public gpg key to it
       def write_tmp_file!
         @tmp_file = Tempfile.new('backup.pub')
+        FileUtils.chown(USER, nil, @tmp_file)
+        FileUtils.chmod(0600, @tmp_file)
         @tmp_file.write(key)
         @tmp_file.close
       end


### PR DESCRIPTION
There exists a race condition where the GPG public key to be crypted to is written out, but if our backup.rb-running user has a permissive umask for file creation, a malicious user could overwrite the key before the key is imported.

This just chowns and chmods the temporary file to be more restrictive to prevent this.
