### PR TITLE
backups fail if the commands return non-zero status codes, using the pope

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    Platform (0.4.0)
     activesupport (3.0.5)
     addressable (2.2.4)
     builder (3.0.0)
@@ -63,7 +64,11 @@ GEM
     net-ssh (2.1.3)
     nokogiri (1.4.4)
     oauth (0.4.4)
+    open4 (1.1.0)
     polyglot (0.3.1)
+    popen4 (0.1.2)
+      Platform (>= 0.4.0)
+      open4 (>= 0.4.0)
     rack (1.2.2)
     rb-fsevent (0.4.0)
     rb-inotify (0.8.5)
@@ -110,6 +115,7 @@ DEPENDENCIES
   net-scp (~> 1.0.4)
   net-sftp (~> 2.0.5)
   net-ssh (~> 2.1.3)
+  popen4 (~> 0.1.2)
   rb-fsevent
   rb-inotify
   rspec

--- a/lib/backup/dependency.rb
+++ b/lib/backup/dependency.rb
@@ -68,6 +68,12 @@ module Backup
           :require => 'json',
           :version => '~> 1.5.1',
           :for     => 'Parsing JSON for HTTParty'
+        },
+
+        'popen4' => {
+          :require => 'popen4',
+          :version => '~> 0.1.2',
+          :for     => 'Executing system commands and receiving output'
         }
       }
     end

--- a/lib/backup/exception/command_failed.rb
+++ b/lib/backup/exception/command_failed.rb
@@ -1,0 +1,8 @@
+# encoding: utf-8
+
+module Backup
+  module Exception
+    class CommandFailed < StandardError
+    end
+  end
+end


### PR DESCRIPTION
I've moved the CLI command to use the popen4 gem, which allows better tracking of the status codes and stdout and stderr messages.  Essential for tracking commands that actually fail.  Before this I was getting successful notifications when my pgdump was failing with database permission errors.
