### PR TITLE
Added support for specifying cloudfiles auth url

### DIFF
--- a/lib/backup/configuration/storage/cloudfiles.rb
+++ b/lib/backup/configuration/storage/cloudfiles.rb
@@ -8,7 +8,7 @@ module Backup
 
           ##
           # Rackspace Cloud Files Credentials
-          attr_accessor :api_key, :username
+          attr_accessor :api_key, :username, :auth_url
 
           ##
           # Rackspace Cloud Files container name and path

--- a/lib/backup/storage/cloudfiles.rb
+++ b/lib/backup/storage/cloudfiles.rb
@@ -10,7 +10,7 @@ module Backup
 
       ##
       # Rackspace Cloud Files Credentials
-      attr_accessor :username, :api_key
+      attr_accessor :username, :api_key, :auth_url
 
       ##
       # Rackspace Cloud Files container name and path
@@ -61,7 +61,8 @@ module Backup
         Fog::Storage.new(
           :provider           => provider,
           :rackspace_username => username,
-          :rackspace_api_key  => api_key
+          :rackspace_api_key  => api_key,
+          :rackspace_auth_url => auth_url
         )
       end
 

--- a/lib/templates/storage/cloudfiles
+++ b/lib/templates/storage/cloudfiles
@@ -7,4 +7,5 @@
     cf.container = 'my_container'
     cf.path      = '/path/to/my/backups'
     cf.keep      = 5
+    cf.auth_url  = 'lon.auth.api.rackspacecloud.com'
   end

--- a/spec/configuration/storage/cloudfiles_spec.rb
+++ b/spec/configuration/storage/cloudfiles_spec.rb
@@ -9,6 +9,7 @@ describe Backup::Configuration::Storage::CloudFiles do
       cf.api_key   = 'my_api_key'
       cf.container = 'my_container'
       cf.path      = 'my_backups'
+      cf.auth_url  = 'lon.auth.api.rackspacecloud.com'
     end
   end
 
@@ -18,6 +19,7 @@ describe Backup::Configuration::Storage::CloudFiles do
     cf.api_key.should   == 'my_api_key'
     cf.container.should == 'my_container'
     cf.path.should      == 'my_backups'
+    cf.auth_url.should  == 'lon.auth.api.rackspacecloud.com'
   end
 
   describe '#clear_defaults!' do
@@ -29,6 +31,7 @@ describe Backup::Configuration::Storage::CloudFiles do
       cf.api_key.should   == nil
       cf.container.should == nil
       cf.path.should      == nil
+      cf.auth_url.should  == nil
     end
   end
 end

--- a/spec/storage/cloudfiles_spec.rb
+++ b/spec/storage/cloudfiles_spec.rb
@@ -11,6 +11,7 @@ describe Backup::Storage::CloudFiles do
       cf.container = 'my_container'
       cf.path      = 'backups'
       cf.keep      = 20
+      cf.auth_url  = 'lon.auth.api.rackspacecloud.com'
     end
   end
 
@@ -24,6 +25,7 @@ describe Backup::Storage::CloudFiles do
     cf.container.should == 'my_container'
     cf.path.should      == 'backups'
     cf.keep.should      == 20
+    cf.auth_url.should  == 'lon.auth.api.rackspacecloud.com'
   end
 
   it 'should use the defaults if a particular attribute has not been defined' do
@@ -48,7 +50,8 @@ describe Backup::Storage::CloudFiles do
       Fog::Storage.expects(:new).with({
         :provider           => 'Rackspace',
         :rackspace_username => 'my_username',
-        :rackspace_api_key  => 'my_api_key'
+        :rackspace_api_key  => 'my_api_key',
+        :rackspace_auth_url => 'lon.auth.api.rackspacecloud.com'
       })
 
       cf.send(:connection)


### PR DESCRIPTION
An extra `auth_url` attribute has been added to the cloudfiles config.

This allows you to specify auth urls for different regions (e.g. to use
the London cloudfiles api you use "lon.auth.api.rackspacecloud.com"
