### PR TITLE
Send exit code 1 to shell after an exception has been thrown

### DIFF
--- a/lib/backup/model.rb
+++ b/lib/backup/model.rb
@@ -266,6 +266,8 @@ module Backup
       Logger.normal "=" * 75 + "\nException that got raised:\n#{exception.class} - #{exception} \n" + "=" * 75 + "\n" + exception.backtrace.join("\n")
       Logger.normal "=" * 75 + "\n\nYou are running Backup version \"#{Backup::Version.current}\" and Ruby version \"#{RUBY_VERSION} (patchlevel #{RUBY_PATCHLEVEL})\" on platform \"#{RUBY_PLATFORM}\".\n"
       Logger.normal "If you've setup a \"Notification\" in your configuration file, the above error will have been sent."
+      #Notifies the shell an exception occured.
+      exit 1 
     end
 
   end


### PR DESCRIPTION
Need to make sure the shell knows about exceptions / problems. This helps when running backup from another app.
