### PR TITLE
make model extendable

### DIFF
--- a/lib/backup/model.rb
+++ b/lib/backup/model.rb
@@ -5,6 +5,10 @@ module Backup
     include Backup::CLI
 
     ##
+    # The parent is used to extend a config
+    attr_accessor :parent
+
+    ##
     # The trigger is used as an identifier for
     # initializing the backup process
     attr_accessor :trigger
@@ -94,10 +98,11 @@ module Backup
     # configuration for the model, it will append the newly created "model" instance
     # to the @all class variable (Array) so it can be accessed by Backup::Finder
     # and any other location
-    def initialize(trigger, label, &block)
+    def initialize(trigger, label, parent, &block)
       @trigger     = trigger
       @label       = label
       @time        = TIME
+      @parent      = parent
 
       @databases   = Array.new
       @archives    = Array.new
@@ -106,8 +111,22 @@ module Backup
       @storages    = Array.new
       @notifiers   = Array.new
       @syncers     = Array.new
-
+      
       instance_eval(&block)
+
+      Backup::Model.all.each {
+        |model|
+        if model.trigger == @parent
+          @databases   = self.databases   | model.databases
+          @archives    = self.archives    | model.archives
+          @encryptors  = self.encryptors  | model.encryptors
+          @compressors = self.compressors | model.compressors
+          @storages    = self.storages    | model.storages
+          @notifiers   = self.notifiers   | model.notifiers
+          @syncers     = self.syncers     | model.syncers
+        end
+      }
+
       Backup::Model.all << self
     end
 


### PR DESCRIPTION
Hi,

I tried to write a way to have extendable model. I wanted to do such a config possible:

``` ruby
Backup::Model.new(:db_backup, 'My Backup', '') do

  database MySQL do |db|
    db.name               = "firstdb"
    db.username           = "firstdb"
    db.password           = "firstdb"
    db.host               = "localhost"
    db.port               = 3306
    db.socket             = "/var/run/mysqld/mysqld.sock"
  end

  database MySQL do |db|
    db.name               = "seconddb"
    db.username           = "seconddb"
    db.password           = "seconddb"
    db.host               = "localhost"
    db.port               = 3306
    db.socket             = "/var/run/mysqld/mysqld.sock"
  end

  compress_with Gzip do |compression|
    compression.best = true
    compression.fast = false
  end

end

Backup::Model.new(:daily, 'My Backup', :db_backup) do

  store_with S3 do |s3|
    s3.access_key_id      = 'my_access_key_id'
    s3.secret_access_key  = 'my_secret_access_key'
    s3.region             = 'us-east-1'
    s3.bucket             = 'bucket-name'
    s3.path               = '/path/to/my/daily-backups'
    s3.keep               = 10
  end

end

Backup::Model.new(:weekly, 'My Backup', :db_backup) do

  store_with S3 do |s3|
    s3.access_key_id      = 'my_access_key_id'
    s3.secret_access_key  = 'my_secret_access_key'
    s3.region             = 'us-east-1'
    s3.bucket             = 'bucket-name'
    s3.path               = '/path/to/my/weekly-backups'
    s3.keep               = 10
  end

end

Backup::Model.new(:monthly, 'My Backup', :db_backup) do

  store_with S3 do |s3|
    s3.access_key_id      = 'my_access_key_id'
    s3.secret_access_key  = 'my_secret_access_key'
    s3.region             = 'us-east-1'
    s3.bucket             = 'bucket-name'
    s3.path               = '/path/to/my/monthly-backups'
    s3.keep               = 10
  end

end

```

I'm very new in ruby, so feel free to make a better implementation if you want to keep this feature.
