### PR TITLE
Don't assume that ENV['HOME'] is set

### DIFF
--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -39,12 +39,14 @@ module Backup
   ##
   # Backup's Environment paths
   USER        = ENV['USER'] || Etc.getpwuid.name
-  PATH        = File.join(ENV['HOME'], 'Backup')
-  DATA_PATH   = File.join(ENV['HOME'], 'Backup', 'data')
-  CONFIG_FILE = File.join(ENV['HOME'], 'Backup', 'config.rb')
-  LOG_PATH    = File.join(ENV['HOME'], 'Backup', 'log')
-  CACHE_PATH  = File.join(ENV['HOME'], 'Backup', '.cache')
-  TMP_PATH    = File.join(ENV['HOME'], 'Backup', '.tmp')
+
+  home_env = ENV.fetch("HOME") { "" }
+  PATH        = File.join(home_env, 'Backup')
+  DATA_PATH   = File.join(home_env, 'Backup', 'data')
+  CONFIG_FILE = File.join(home_env, 'Backup', 'config.rb')
+  LOG_PATH    = File.join(home_env, 'Backup', 'log')
+  CACHE_PATH  = File.join(home_env, 'Backup', '.cache')
+  TMP_PATH    = File.join(home_env, 'Backup', '.tmp')
 
   ##
   # Autoload Backup base files


### PR DESCRIPTION
Hi, 

On a project in which I use backup, I start some resque runners with 'god'. This fails because backup assumes that the HOME environment var is set, which is not the case when god is started as a daemon (here is a detailed writeup if you're interested: http://t.co/lH5dfXu9 )

I have patched this and verified that the patch works. Note that I have not changed the use of ENV['HOME'] in backup/storage/local.rb because I'm unsure about what is safe to assume in that context. 

Thanks for this great gem!

/Jacob
