### PR TITLE
Fixing the invoke save option of redis backups.

### DIFF
--- a/lib/backup/database/redis.rb
+++ b/lib/backup/database/redis.rb
@@ -82,7 +82,7 @@ module Backup
       # Tells Redis to persist the current state of the
       # in-memory database to the persisted dump file
       def invoke_save!
-        response = run("#{ utility('redis-cli') } #{ credential_options } #{ connectivity_options } #{ additional_options } SAVE")
+        response = `#{ utility('redis-cli') } #{ credential_options } #{ connectivity_options } #{ additional_options } SAVE`
         unless response =~ /OK/
           Logger.error "Could not invoke the Redis SAVE command. The #{ database } file might not contain the most recent data."
           Logger.error "Please check if the server is running, the credentials (if any) are correct, and the host/port/socket are correct."


### PR DESCRIPTION
The invoke save option for Redis backups is not working. Currently it is using the `run` command and assuming that this function returns the STDOUT of the shell command.

This is not the case so have replaced the call to `run` with a standard ruby backtick command.
