### PR TITLE
added support for parallel bzip2 compressor (pbzip2)

### DIFF
--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -34,7 +34,7 @@ module Backup
   #  database MySQL do |mysql|
   DATABASES   = ['MySQL', 'PostgreSQL', 'MongoDB', 'Redis', 'Riak']
   STORAGES    = ['S3', 'CloudFiles', 'Ninefold', 'Dropbox', 'FTP', 'SFTP', 'SCP', 'RSync', 'Local']
-  COMPRESSORS = ['Gzip', 'Bzip2', 'Lzma']
+  COMPRESSORS = ['Gzip', 'Bzip2', 'Lzma', 'Pbzip2']
   ENCRYPTORS  = ['OpenSSL', 'GPG']
   SYNCERS     = ['RSync', 'S3']
   NOTIFIERS   = ['Mail', 'Twitter', 'Campfire', 'Presently', 'Prowl', 'Hipchat']
@@ -123,6 +123,7 @@ module Backup
     autoload :Base,  File.join(COMPRESSOR_PATH, 'base')
     autoload :Gzip,  File.join(COMPRESSOR_PATH, 'gzip')
     autoload :Bzip2, File.join(COMPRESSOR_PATH, 'bzip2')
+    autoload :Pbzip2, File.join(COMPRESSOR_PATH, 'pbzip2')
     autoload :Lzma,  File.join(COMPRESSOR_PATH, 'lzma')
   end
 
@@ -173,6 +174,7 @@ module Backup
       autoload :Base,  File.join(CONFIGURATION_PATH, 'compressor', 'base')
       autoload :Gzip,  File.join(CONFIGURATION_PATH, 'compressor', 'gzip')
       autoload :Bzip2, File.join(CONFIGURATION_PATH, 'compressor', 'bzip2')
+      autoload :Pbzip2, File.join(CONFIGURATION_PATH, 'compressor', 'pbzip2')
       autoload :Lzma,  File.join(CONFIGURATION_PATH, 'compressor', 'lzma')
     end
 

--- a/lib/backup/compressor/pbzip2.rb
+++ b/lib/backup/compressor/pbzip2.rb
@@ -1,0 +1,76 @@
+# encoding: utf-8
+
+module Backup
+  module Compressor
+    class Pbzip2 < Base
+
+      ##
+      # Tells Backup::Compressor::Pbzip2 to compress
+      # better (-9) rather than faster when set to true
+      attr_writer :best
+
+      ##
+      # Tells Backup::Compressor::Pbzip2 to compress
+      # faster (-1) rather than better when set to true
+      attr_writer :fast
+
+      ##
+      # Tells Backup::Compressor::Pbzip2 how many processors
+      # use, by default autodetect is used
+      attr_writer :processors
+
+      ##
+      # Creates a new instance of Backup::Compressor::Pbzip2 and
+      # configures it to either compress faster or better
+      # bzip2 compresses by default with -9 (best compression)
+      # and lower block sizes don't make things significantly faster
+      # (according to official bzip2 docs)
+      def initialize(&block)
+        load_defaults!
+
+        @best ||= false
+        @fast ||= false
+        @processors ||= nil
+
+        instance_eval(&block) if block_given?
+      end
+
+      ##
+      # Performs the compression of the packages backup file
+      def perform!
+        log!
+        run("#{ utility(:pbzip2) } #{ options } '#{ Backup::Model.file }'")
+        Backup::Model.extension += '.bz2'
+      end
+
+    private
+
+      ##
+      # Combines the provided options and returns a pbzip2 options string
+      def options
+        (best + fast + processors).join("\s")
+      end
+
+      ##
+      # Returns the pbzip2 option syntax for compressing
+      # setting @best to true is redundant, as pbzip2 compresses best by default
+      def best
+        return ['--best'] if @best; []
+      end
+
+      ##
+      # Returns the pbzip2 option syntax for compressing
+      # (not significantly) faster when @fast is set to true
+      def fast
+        return ['--fast'] if @fast; []
+      end
+
+      ##
+      # Returns the pbzip2 option syntax for compressing
+      # using given count of cpus
+      def processors
+        return ['-p' + @processors.to_s] if @processors; []
+      end
+    end
+  end
+end

--- a/lib/backup/configuration/compressor/pbzip2.rb
+++ b/lib/backup/configuration/compressor/pbzip2.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+
+module Backup
+  module Configuration
+    module Compressor
+      class Pbzip2 < Base
+        class << self
+
+          ##
+          # Tells Backup::Compressor::Pbzip2 to compress
+          # better (-9) which is bzip2 default anyway
+          attr_accessor :best
+
+          ##
+          # Tells Backup::Compressor::Pbzip2 to compress
+          # faster (-1) (but not significantly faster)
+          attr_accessor :fast
+
+          ##                                                                                                                                                                         
+          # Tells Backup::Compressor::Pbzip2 how many processors                                                                                                                     
+          # use, by default autodetect is used                                                                                                                                       
+          attr_writer :processors
+
+        end
+      end
+    end
+  end
+end

--- a/lib/templates/compressor/pbzip2
+++ b/lib/templates/compressor/pbzip2
@@ -1,0 +1,7 @@
+  ##
+  # Pbzip2 [Compressor]
+  #
+  compress_with Pbzip2 do |compression|
+    compression.best = true
+    compression.fast = false
+  end

--- a/spec/compressor/pbzip2_spec.rb
+++ b/spec/compressor/pbzip2_spec.rb
@@ -1,0 +1,63 @@
+# encoding: utf-8
+
+require File.dirname(__FILE__) + '/../spec_helper'
+
+describe Backup::Compressor::Pbzip2 do
+  let(:compressor) { Backup::Compressor::Pbzip2.new }
+
+  before do
+    Backup::Model.extension = 'tar'
+  end
+
+  describe 'the options' do
+    it do
+      compressor.send(:best).should == []
+    end
+
+    it do
+      compressor.send(:fast).should == []
+    end
+    
+    it do
+      compressor.send(:processors).should == []
+    end
+  end
+
+  describe '#perform!' do
+    before do
+      [:run, :utility].each { |method| compressor.stubs(method) }
+    end
+
+    it 'should perform the compression' do
+      compressor.expects(:utility).with(:pbzip2).returns(:pbzip2)
+      compressor.expects(:run).with("pbzip2  '#{ File.join(Backup::TMP_PATH, "#{ Backup::TIME }.#{ Backup::TRIGGER }.tar") }'")
+      compressor.perform!
+    end
+
+    it 'should perform the compression with the --best, --fast and -p1 options' do
+      compressor = Backup::Compressor::Pbzip2.new do |c|
+        c.best = true
+        c.fast = true
+        c.processors = 1
+      end
+
+      compressor.stubs(:utility).returns(:pbzip2)
+      compressor.expects(:run).with("pbzip2 --best --fast -p1 '#{ File.join(Backup::TMP_PATH, "#{ Backup::TIME }.#{ Backup::TRIGGER }.tar") }'")
+      compressor.perform!
+    end
+
+    it 'should set the class variable @extension (Backup::Model.extension) to .bz2' do
+      compressor.stubs(:utility).returns(:pbzip2)
+      compressor.expects(:run)
+
+      Backup::Model.extension.should == 'tar'
+      compressor.perform!
+      Backup::Model.extension.should == 'tar.bz2'
+    end
+
+    it 'should log' do
+      Backup::Logger.expects(:message).with("Backup::Compressor::Pbzip2 started compressing the archive.")
+      compressor.perform!
+    end
+  end
+end


### PR DESCRIPTION
Hi,

I'm working for ragnarson.com and as part of my daily task I've added support for pbzip2 compressor to your backup gem. It's basically copy/paste of bzip2 compressor with added '-p' option (for processors count). This '-p' is optional, by default pbzip2 uses all available cpus. I've also written specs everything runs smoothly, maybe I'll expand it in the future. Only things I haven't edited are gem version and README.md. It would be great if you include my code into gem, we won't have to keep separate gem version at our servers.

---

Szymon
