### PR TITLE
Added ability to dump all databases for MySQL.

### DIFF
--- a/lib/backup/configuration/database/mysql.rb
+++ b/lib/backup/configuration/database/mysql.rb
@@ -33,6 +33,10 @@ module Backup
           ##
           # Path to mysqldump utility (optional)
           attr_accessor :mysqldump_utility
+          
+          ##
+          # Whether to dump all databases
+          attr_accessor :all
 
         end
       end

--- a/spec/database/mysql_spec.rb
+++ b/spec/database/mysql_spec.rb
@@ -12,6 +12,7 @@ describe Backup::Database::MySQL do
       db.host      = 'localhost'
       db.port      = '123'
       db.socket    = '/mysql.sock'
+      db.all       = false
 
       db.skip_tables = ['logs', 'profiles']
       db.only_tables = ['users', 'pirates']
@@ -50,6 +51,7 @@ describe Backup::Database::MySQL do
         db.host.should      be_nil
         db.port.should      be_nil
         db.socket.should    be_nil
+        db.all.should       == false
 
         db.skip_tables.should         == []
         db.only_tables.should         == []
@@ -69,6 +71,7 @@ describe Backup::Database::MySQL do
           db.host       = 'db_host'
           db.port       = 789
           db.socket     = '/foo.sock'
+          db.all        = false
 
           db.skip_tables = ['skip', 'tables']
           db.only_tables = ['only', 'tables']
@@ -83,6 +86,7 @@ describe Backup::Database::MySQL do
         db.host.should      == 'db_host'
         db.port.should      == 789
         db.socket.should    == '/foo.sock'
+        db.all.should       == false
 
         db.skip_tables.should         == ['skip', 'tables']
         db.only_tables.should         == ['only', 'tables']
@@ -192,6 +196,24 @@ describe Backup::Database::MySQL do
       before { db.additional_options = [] }
       it 'should return an empty string' do
         db.send(:user_options).should == ''
+      end
+    end
+  end
+
+  describe '#all' do
+    it 'should return the value for the all option' do
+      db.send(:all).should == false
+      db.send(:name).should == 'mydatabase'
+    end
+
+    context 'when all is set' do
+      it 'should return all for database name' do
+        db.all = true
+        db.send(:name).should == "all"
+        db.send(:mysqldump).should ==
+            "/path/to/mysqldump --user='someuser' --password='secret' " +
+            "--host='localhost' --port='123' --socket='/mysql.sock' " +
+            "--single-transaction --quick --all-databases"
       end
     end
   end

--- a/templates/cli/utility/database/mysql
+++ b/templates/cli/utility/database/mysql
@@ -14,4 +14,6 @@
     # Optional: Use to set the location of this utility
     #   if it cannot be found by name in your $PATH
     # db.mysqldump_utility = '/opt/local/bin/mysqldump'
+		# Optional: Use to dump all databases instead of having to specify the tables
+		# db.all = true
   end


### PR DESCRIPTION
This applies to issue #178.

Currently, if you want to dump all databases, you need to look through your database table similar to:

``` ruby
client = Mysql2::Client.new(options)
results = client.query("SHOW DATABASES")
results.collect { |row| row['Database'] }
```

Here I have added an option (for MySQL only at present) to specify you want to dump all databases:

``` ruby
database MySQL do |database|
    database.username = 'my_username'
    database.password = 'my_password'
    database.all = true
    database.additional_options = ['--single-transaction', '--quick']
end
```

This will pass the `--all-databases` option to mysqldump.

Options `db.skip_tables` and `db.only_tables` are ignored if `db.all = true` (for now, I guess you could still ignore tables but the database name would need to be specified which added an extra layer of complexity for something people may not be interested in if they are dumping all databases).

I added rspec tests, but please note I am new to rspec. All tests pass.

Thanks,
Craig
