### PR TITLE
Added command to check if a dependency is already installed

### DIFF
--- a/lib/backup/cli/utility.rb
+++ b/lib/backup/cli/utility.rb
@@ -187,7 +187,7 @@ module Backup
       ##
       # [Dependencies]
       # Returns a list of Backup's dependencies
-      desc 'dependencies', 'Display the list of dependencies for Backup, or install them through Backup.'
+      desc 'dependencies', 'Display the list of dependencies for Backup, check the installation status, or install them through Backup.'
       method_option :install, :type => :string
       method_option :list,    :type => :boolean
       method_option :installed, :type => :string


### PR DESCRIPTION
As I use the tool with provisioning and don't want to wait every time for all `gem install` to run through, I added a n option to the `backup dependencies` command, making it possible to check if a dependency is already installed using `backup dependencies --installed <name>`. It simply wraps the `gem list -i -v 'version' 'name'` command.
