### PR TITLE
Allow setting some path variables at run time.

### DIFF
--- a/lib/backup/config.rb
+++ b/lib/backup/config.rb
@@ -11,8 +11,8 @@ module Backup
     }
 
     class << self
-      attr_reader :user, :root_path, :config_file,
-                  :data_path, :log_path, :cache_path, :tmp_path
+      attr_reader :user, :root_path, :config_file
+      attr_accessor :data_path, :log_path, :cache_path, :tmp_path
 
       ##
       # Setup required paths based on the given options


### PR DESCRIPTION
This lets conifg.rb have something like: Backup::Config.tmp_path = '/mnt/tmp'

Which can be more convenient than running: backup perform -t trigger --tmp-path '/mnt/tmp'
