### PR TITLE
Fixed wildcard matching

### DIFF
--- a/lib/backup/cli/utility.rb
+++ b/lib/backup/cli/utility.rb
@@ -57,7 +57,7 @@ module Backup
         # and finding trigger names matching wildcard
         triggers = options[:trigger].split(",")
         triggers.map!(&:strip).map! {|t|
-          t.include?('*') ? Model.find_matching(t) : t
+          t.include?('*') ? Model.find_matching(t).map(&:trigger) : t
         }.flatten!
 
         ##

--- a/spec/cli/utility_spec.rb
+++ b/spec/cli/utility_spec.rb
@@ -62,6 +62,31 @@ describe 'Backup::CLI::Utility' do
       end.not_to raise_error
     end
 
+    it 'should perform backups for the multiple triggers when using wildcard' do
+      Backup::Logger.expects(:quiet=).in_sequence(s)
+      Backup::Config.expects(:update).in_sequence(s)
+      Backup::Config.expects(:load_config!).in_sequence(s)
+
+      FileUtils.expects(:mkdir_p).in_sequence(s).with(Backup::Config.log_path)
+      FileUtils.expects(:mkdir_p).in_sequence(s).with(Backup::Config.cache_path)
+      FileUtils.expects(:mkdir_p).in_sequence(s).with(Backup::Config.tmp_path)
+
+      Backup::Logger.expects(:truncate!)
+
+      model_a.expects(:prepare!).in_sequence(s)
+      model_a.expects(:perform!).in_sequence(s)
+      Backup::Logger.expects(:clear!).in_sequence(s)
+
+      model_b.expects(:prepare!).in_sequence(s)
+      model_b.expects(:perform!).in_sequence(s)
+      Backup::Logger.expects(:clear!).in_sequence(s)
+
+      expect do
+        ARGV.replace(['perform', '-t', 'test_trigger_*'])
+        cli.start
+      end.not_to raise_error
+    end
+
     context 'when errors occur' do
       it 'should log the error and exit' do
         Backup::Logger.stubs(:quiet=).raises(SystemCallError, 'yikes!')


### PR DESCRIPTION
Model.find_matching returns model instances, but CLI::Utility.perform
method expects triggers. Added extracting triggers from matching models
before trying to perform backups.

Also fixed spec:
Model initializer already adds instance to Backup::Model.all array,
so adding it explicitely in before block caused Backup::Model.all
to contain duplicates.
