### PR TITLE
Popen4 issue: Fixing the invoke save option of redis backups.

### DIFF
--- a/lib/backup/database/redis.rb
+++ b/lib/backup/database/redis.rb
@@ -65,8 +65,8 @@ module Backup
       # Tells Redis to persist the current state of the
       # in-memory database to the persisted dump file
       def invoke_save!
-        response = run("#{ redis_cli_utility } #{ credential_options } " +
-                       "#{ connectivity_options } #{ user_options } SAVE")
+        response = `#{ redis_cli_utility } #{ credential_options } #{ connectivity_options } #{ user_options } SAVE`
+                       
         unless response =~ /OK/
           raise Errors::Database::Redis::CommandError, <<-EOS
             Could not invoke the Redis SAVE command.


### PR DESCRIPTION
The invoke save option for Redis backups is not working. Currently it is using the run command and assuming that this function returns the STDOUT of the shell command.

This is not the case so have replaced the call to run with a standard ruby backtick command.

This is a semi-duplicate of #217 which I submitted. There has been a regression since this pull request was submitted.
