### PR TITLE
Use BGSAVE to take a snapshot of a Redis db

### DIFF
--- a/lib/backup/database/redis.rb
+++ b/lib/backup/database/redis.rb
@@ -17,7 +17,7 @@ module Backup
       attr_accessor :host, :port, :socket
 
       ##
-      # Determines whether Backup should invoke the SAVE command through
+      # Determines whether Backup should invoke the BGSAVE command through
       # the 'redis-cli' utility to persist the most recent data before
       # copying over the dump file
       attr_accessor :invoke_save
@@ -66,10 +66,10 @@ module Backup
       # in-memory database to the persisted dump file
       def invoke_save!
         response = run("#{ redis_cli_utility } #{ credential_options } " +
-                       "#{ connectivity_options } #{ user_options } SAVE")
+                       "#{ connectivity_options } #{ user_options } BGSAVE")
         unless response =~ /OK/
           raise Errors::Database::Redis::CommandError, <<-EOS
-            Could not invoke the Redis SAVE command.
+            Could not invoke the Redis BGSAVE command.
             The #{ database } file might not contain the most recent data.
             Please check if the server is running, the credentials (if any) are correct,
             and the host/port/socket are correct.

--- a/spec/database/redis_spec.rb
+++ b/spec/database/redis_spec.rb
@@ -167,7 +167,7 @@ describe Backup::Database::Redis do
       it 'should run the redis-cli command string' do
         db.expects(:run).with(
           '/path/to/redis-cli credential_options_output ' +
-          'connectivity_options_output user_options_output SAVE'
+          'connectivity_options_output user_options_output BGSAVE'
         ).returns('result OK for command')
 
         expect do
@@ -185,7 +185,7 @@ describe Backup::Database::Redis do
           db.send(:invoke_save!)
         end.to raise_error {|err|
           err.should be_an_instance_of Backup::Errors::Database::Redis::CommandError
-          err.message.should match(/Could not invoke the Redis SAVE command/)
+          err.message.should match(/Could not invoke the Redis BGSAVE command/)
           err.message.should match(/The database_filename file/)
           err.message.should match(/Redis CLI response: result not ok/)
         }


### PR DESCRIPTION
The Redis SAVE command should almost never be called in production
environments since it will block all the other clients. Its BGSAVE
variant should be use instead.

See the following links for more details on the two commands:

SAVE    http://redis.io/commands/save
BGSAVE  http://redis.io/commands/bgsave
