### PR TITLE
update for riak backup output file

### DIFF
--- a/lib/backup/database/riak.rb
+++ b/lib/backup/database/riak.rb
@@ -48,7 +48,7 @@ module Backup
         if @model.compressor
           @model.compressor.compress_with do |command, ext|
             run("#{ command } -c #{ backup_file }-#{ node } > #{ backup_file + ext }")
-            FileUtils.rm_f(backup_file)
+            FileUtils.rm_f("#{ backup_file }-#{ node }")
           end
         end
       end


### PR DESCRIPTION
riak-admin backup appends the node name on the end of the backup file specified.  Compress subsequently fails because the filename provided to riak-admin isn't the actual filename created.  This patch appends the node name to the input file for the compressor.
