### PR TITLE
Fix segfaults with Popen4 and Ruby 1.8.7

### DIFF
--- a/lib/backup/cli/helpers.rb
+++ b/lib/backup/cli/helpers.rb
@@ -21,6 +21,10 @@ module Backup
 
         begin
           out, err = '', ''
+          # popen4 doesn't work in 1.8.7 with stock versions of ruby shipped
+          # with major OSs. Hack to make it stop segfaulting.  
+          # See: https://github.com/engineyard/engineyard/issues/115
+          GC.disable
           ps = Open4.popen4(command) do |pid, stdin, stdout, stderr|
             stdin.close
             out, err = stdout.read.strip, stderr.read.strip
@@ -30,6 +34,8 @@ module Backup
             Failed to execute system command on #{ RUBY_PLATFORM }
             Command was: #{ command }
           EOS
+        ensure
+          GC.enable
         end
 
         if ps.success?


### PR DESCRIPTION
When using Ruby 1.8.7 with Popen4 ruby regularly segfaults.

This is a well-known work around for that issue.

I was able to easily reproduce this issue on: 
- Ubuntu 12.04 +  ruby 1.8.7 (2011-06-30 patchlevel 352) [x86_64-linux]
- Take a dump that lasts a couple minutes, GC will come around and segfault your face!

See: 
http://tickets.opscode.com/browse/CHEF-2916
https://github.com/engineyard/engineyard/issues/115
