### PR TITLE
Add Dead Man's Snitch as a notifier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Below you find a list of components that Backup currently supports. If you'd lik
 - Presently
 - Prowl
 - Hipchat
+- Dead Man's Snitch
 
 [Notifiers Wiki Page](https://github.com/meskyanichi/backup/wiki/Notifiers)
 
@@ -130,7 +131,7 @@ Below you find a list of components that Backup currently supports. If you'd lik
 A sample Backup configuration file
 ----------------------------------
 
-This is a Backup configuration file. Check it out and read the explanation below.  
+This is a Backup configuration file. Check it out and read the explanation below.
 Backup has a [great wiki](https://github.com/meskyanichi/backup/wiki) which explains each component of Backup in detail.
 
 ``` rb

--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -106,6 +106,7 @@ module Backup
     autoload :Campfire,  File.join(NOTIFIER_PATH, 'campfire')
     autoload :Prowl,     File.join(NOTIFIER_PATH, 'prowl')
     autoload :Hipchat,   File.join(NOTIFIER_PATH, 'hipchat')
+    autoload :DMS,       File.join(NOTIFIER_PATH, 'dms')
   end
 
   ##

--- a/lib/backup/config.rb
+++ b/lib/backup/config.rb
@@ -116,7 +116,7 @@ module Backup
               { 'RSync' => ['Push', 'Pull', 'Local'] }
             ],
             # Notifiers
-            ['Mail', 'Twitter', 'Campfire', 'Prowl', 'Hipchat']
+            ['Mail', 'Twitter', 'Campfire', 'Prowl', 'Hipchat', 'DMS']
           ]
         )
       end

--- a/lib/backup/notifier/dms.rb
+++ b/lib/backup/notifier/dms.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+
+module Backup
+  module Notifier
+    class DMS < Base
+
+      ##
+      # Snitch URL
+      # The URL Dead Man's Snitch gives you when you create a new snitch
+      attr_accessor :snitch_url
+
+      def initialize(model, &block)
+        super(model)
+
+        instance_eval(&block) if block_given?
+
+        @on_success = true
+        @on_warning = true
+        @on_failure = false # we want DMS to work
+      end
+
+      private
+
+      def notify!(status)
+        `#{cmd}`
+      end
+
+      def cmd
+        "curl -d 'm=#{message}' #{snitch_url}"
+      end
+
+      def message
+        @model.send(:elapsed_time)
+      end
+    end
+  end
+end

--- a/spec/notifier/dms_spec.rb
+++ b/spec/notifier/dms_spec.rb
@@ -1,0 +1,80 @@
+# encoding: utf-8
+
+require File.expand_path('../../spec_helper.rb', __FILE__)
+
+describe Backup::Notifier::DMS do
+  let(:model) { Backup::Model.new(:test_trigger, 'test label') }
+  let(:notifier) do
+    Backup::Notifier::DMS.new(model) do |dms|
+      dms.snitch_url = 'https://nosnch.test/token'
+    end
+  end
+
+  it 'should be a subclass of Notifier::Base' do
+    Backup::Notifier::DMS.
+      superclass.should == Backup::Notifier::Base
+  end
+
+  describe '#initialize' do
+    after { Backup::Notifier::DMS.clear_defaults! }
+
+    it 'should load pre-configured defaults through Base' do
+      Backup::Notifier::DMS.any_instance.expects(:load_defaults!)
+      notifier
+    end
+
+    it 'should pass the model reference to Base' do
+      notifier.instance_variable_get(:@model).should == model
+    end
+
+    it "should use the specified snitch_url" do
+      notifier.snitch_url.should eql('https://nosnch.test/token')
+    end
+
+    it "should set on_success to true" do
+      notifier.on_success.should be_true
+    end
+
+    it "should not allow overriding on_success" do
+      notifier = Backup::Notifier::DMS.new(model) do |dms|
+        dms.on_success = false
+      end
+
+      notifier.on_success.should be_true
+    end
+
+    it "should set on_warning to true" do
+      notifier.on_warning.should be_true
+    end
+
+    it "should not allow overriding on_warning" do
+      notifier = Backup::Notifier::DMS.new(model) do |dms|
+        dms.on_warning = false
+      end
+
+      notifier.on_warning.should be_true
+    end
+
+    it "should set on_failure to false" do
+      notifier.on_failure.should be_false
+    end
+
+    it "should not allow overriding on_failure" do
+      notifier = Backup::Notifier::DMS.new(model) do |dms|
+        dms.on_failure = false
+      end
+
+      notifier.on_failure.should be_false
+    end
+  end # describe '#initialize'
+
+  describe '#notify!' do
+    it "should execute the command" do
+      model.stubs(:elapsed_time).returns('00:12:23')
+
+      notifier.expects(:'`').with("curl -d 'm=00:12:23' https://nosnch.test/token")
+
+      notifier.send(:notify!, :success)
+    end
+  end # describe '#notify!'
+end


### PR DESCRIPTION
[Dead Man's Snitch](https://deadmanssnitch.com/) is a service I create that lets you know when something doesn't happen during a specified interval. This is the code to add DMS as a notifier.

I override all of the on_\* configs since the service really wants to know about anything but failure. The one question I had was, if there is a warning, does that still count as success? Maybe I should leave the on_warning up to the user but override the on_success and on_failure?
