### PR TITLE
Update thor dependency to allow version 0.16.0

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
 
   ##
   # Gem dependencies
-  gem.add_dependency 'thor',  ['~> 0.15.4']
+  gem.add_dependency 'thor',  ['>= 0.15.4', '< 2']
   gem.add_dependency 'open4', ['~> 1.3.0']
 
 end


### PR DESCRIPTION
Version constraint also allows any yet-to-be-released 1.x version of Thor, which will be backward compatible with current releases.
