### PR TITLE
find should follow symlinks

### DIFF
--- a/lib/backup/syncer/cloud/base.rb
+++ b/lib/backup/syncer/cloud/base.rb
@@ -128,7 +128,7 @@ module Backup
           # Returns a String of file paths and their md5 hashes.
           def local_hashes
             Logger.message("\s\sGenerating checksums for '#{ @directory }'")
-            `find #{ @directory } -print0 | xargs -0 openssl md5 2> /dev/null`
+            `find -L #{ @directory } -print0 | xargs -0 openssl md5 2> /dev/null`
           end
 
           ##


### PR DESCRIPTION
I was trying to sync a local repository on S3 (without archiving) and it just didn't work.
After a bit of digging, I found out it was only an issue with symbolic links.

It appears `find #{directory} -print0` in the `local_hashes` method need the `-L` option to follow symbolic links.

I didn't add a spec, because reading at them it seems you never really test on actual repositories but stub them. If i'm reading wrong or if you have any idea how I could test this, please point me at the right direction and a spec will follow.
