### PR TITLE
Add support for notifying via Pushover

### DIFF
--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -106,6 +106,7 @@ module Backup
     autoload :Campfire,  File.join(NOTIFIER_PATH, 'campfire')
     autoload :Prowl,     File.join(NOTIFIER_PATH, 'prowl')
     autoload :Hipchat,   File.join(NOTIFIER_PATH, 'hipchat')
+    autoload :Pushover,  File.join(NOTIFIER_PATH, 'pushover')
   end
 
   ##

--- a/lib/backup/config.rb
+++ b/lib/backup/config.rb
@@ -116,7 +116,7 @@ module Backup
               { 'RSync' => ['Push', 'Pull', 'Local'] }
             ],
             # Notifiers
-            ['Mail', 'Twitter', 'Campfire', 'Prowl', 'Hipchat']
+            ['Mail', 'Twitter', 'Campfire', 'Prowl', 'Hipchat', 'Pushover']
           ]
         )
       end

--- a/lib/backup/notifier/pushover.rb
+++ b/lib/backup/notifier/pushover.rb
@@ -1,0 +1,88 @@
+# encoding: utf-8
+require 'net/https'
+
+module Backup
+  module Notifier
+    class Pushover < Base
+
+      ##
+      # The API User Token
+      attr_accessor :user
+
+      ##
+      # The API Application Token
+      attr_accessor :token
+
+      ##
+      # The user's device identifier to sent he message directly to that device rather than all of the user's devices
+      attr_accessor :device
+
+      ##
+      # The message title
+      attr_accessor :title
+
+      ##
+      # The priority of the notification
+      attr_accessor :priority
+
+      def initialize(model, &block)
+        super(model)
+
+        instance_eval(&block) if block_given?
+      end
+
+      private
+
+      ##
+      # Notify the user of the backup operation results.
+      # `status` indicates one of the following:
+      #
+      # `:success`
+      # : The backup completed successfully.
+      # : Notification will be sent if `on_success` was set to `true`
+      #
+      # `:warning`
+      # : The backup completed successfully, but warnings were logged
+      # : Notification will be sent, including a copy of the current
+      # : backup log, if `on_warning` was set to `true`
+      #
+      # `:failure`
+      # : The backup operation failed.
+      # : Notification will be sent, including the Exception which caused
+      # : the failure, the Exception's backtrace, a copy of the current
+      # : backup log and other information if `on_failure` was set to `true`
+      #
+      def notify!(status)
+        name = case status
+               when :success then 'Success'
+               when :failure then 'Failure'
+               when :warning then 'Warning'
+               end
+        message = "[Backup::%s] #{@model.label} (#{@model.trigger})" % name
+
+        send_message(message)
+      end
+
+      # Push a message via the Pushover API
+      def send_message(message)
+        url = URI.parse("https://api.pushover.net/1/messages.json")
+
+        request = Net::HTTP::Post.new(url.path)
+        request.set_form_data(parameters.merge ({:message => message}))
+        response = Net::HTTP.new(url.host, url.port)
+
+        response.use_ssl = true
+        response.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+        response.start {|http| http.request(request) }
+      end
+
+      # List available parameters
+      def parameters
+        @values = {}
+        [:token, :user, :message, :title, :priority, :device].each { |k| @values.merge! k => self.instance_variable_get("@#{k}") }
+        @values
+      end
+    end
+  end
+end

--- a/spec/cli/utility_spec.rb
+++ b/spec/cli/utility_spec.rb
@@ -219,7 +219,7 @@ describe 'Backup::CLI::Utility' do
           [--syncers=SYNCERS]          # (cloud_files, rsync_local, rsync_pull, rsync_push, s3)
           [--encryptors=ENCRYPTORS]    # (gpg, openssl)
           [--compressors=COMPRESSORS]  # (bzip2, custom, gzip, lzma, pbzip2)
-          [--notifiers=NOTIFIERS]      # (campfire, hipchat, mail, prowl, twitter)
+          [--notifiers=NOTIFIERS]      # (campfire, hipchat, mail, prowl, pushover, twitter)
           [--archives]
           [--splitter]                 # use `--no-splitter` to disable
                                       # Default: true

--- a/spec/notifier/pushover_spec.rb
+++ b/spec/notifier/pushover_spec.rb
@@ -1,0 +1,123 @@
+# encoding: utf-8
+
+require File.expand_path('../../spec_helper.rb', __FILE__)
+
+describe Backup::Notifier::Pushover do
+  let(:model) { Backup::Model.new(:test_trigger, 'test label') }
+  let(:notifier) do
+    Backup::Notifier::Pushover.new(model) do |notifier|
+      notifier.user = 'user_token'
+      notifier.token = 'app_token'
+      notifier.title = 'title'
+    end
+  end
+
+  it 'should be a subclass of Notifier::Base' do
+    Backup::Notifier::Pushover.
+      superclass.should == Backup::Notifier::Base
+  end
+
+  describe '#initialize' do
+    after { Backup::Notifier::Pushover.clear_defaults! }
+
+    it 'should load pre-configured defaults through Base' do
+      Backup::Notifier::Pushover.any_instance.expects(:load_defaults!)
+      notifier
+    end
+
+    it 'should pass the model reference to Base' do
+      notifier.instance_variable_get(:@model).should == model
+    end
+
+    context 'when no pre-configured defaults have been set' do
+      it 'should use the values given' do
+        notifier.user.should       == 'user_token'
+        notifier.token.should      == 'app_token'
+        notifier.device.should     be_nil
+        notifier.priority.should   be_nil
+
+        notifier.on_success.should == true
+        notifier.on_warning.should == true
+        notifier.on_failure.should == true
+      end
+
+      it 'should use default values if none are given' do
+        notifier = Backup::Notifier::Pushover.new(model)
+        notifier.token.should      be_nil
+        notifier.user.should       be_nil
+        notifier.device.should     be_nil
+        notifier.priority.should   be_nil
+
+        notifier.on_success.should == true
+        notifier.on_warning.should == true
+        notifier.on_failure.should == true
+      end
+    end # context 'when no pre-configured defaults have been set'
+
+    context 'when pre-configured defaults have been set' do
+      before do
+        Backup::Notifier::Pushover.defaults do |n|
+          n.token          = 'the_token'
+          n.user           = 'the_user'
+          n.on_failure     = false
+        end
+      end
+
+      it 'should use pre-configured defaults' do
+        notifier = Backup::Notifier::Pushover.new(model)
+
+        notifier.token.should      == 'the_token'
+        notifier.user.should       == 'the_user'
+
+        notifier.on_success.should == true
+        notifier.on_warning.should == true
+        notifier.on_failure.should == false
+      end
+
+      it 'should override pre-configured defaults' do
+        notifier = Backup::Notifier::Pushover.new(model) do |n|
+          n.token          = 'new_token'
+          n.user           = 'new_user'
+          n.on_success     = false
+          n.on_failure     = true
+        end
+
+        notifier.token.should          == 'new_token'
+        notifier.user.should           == 'new_user'
+
+        notifier.on_success.should     == false
+        notifier.on_warning.should     == true
+        notifier.on_failure.should     == true
+      end
+    end # context 'when pre-configured defaults have been set'
+  end # describe '#initialize'
+
+  describe '#notify!' do
+    context 'when status is :success' do
+      it 'should send Success message' do
+        notifier.expects(:send_message).with(
+          '[Backup::Success] test label (test_trigger)'
+        )
+        notifier.send(:notify!, :success)
+      end
+    end
+
+    context 'when status is :warning' do
+      it 'should send Warning message' do
+        notifier.expects(:send_message).with(
+          '[Backup::Warning] test label (test_trigger)'
+        )
+        notifier.send(:notify!, :warning)
+      end
+    end
+
+    context 'when status is :failure' do
+      it 'should send Failure message' do
+        notifier.expects(:send_message).with(
+          '[Backup::Failure] test label (test_trigger)'
+        )
+        notifier.send(:notify!, :failure)
+      end
+    end
+  end # describe '#notify!'
+end

--- a/templates/cli/utility/notifier/pushover
+++ b/templates/cli/utility/notifier/pushover
@@ -1,0 +1,11 @@
+  ##
+  # Pushover [Notifier]
+  #
+  notify_by Pushover do |push|
+    push.on_success = true
+    push.on_warning = true
+    push.on_failure = true
+
+    push.user       = "USER_TOKEN"
+    push.token      = "APP_TOKEN"
+  end


### PR DESCRIPTION
Pushover provides an API through which you can push notifications to registered applications. This change is to support notification via this API. It uses the [Pushover Gem](https://github.com/erniebrodeur/pushover) to do this.
