### PR TITLE
updated hipchat dependency to ~> 0.7.0

### DIFF
--- a/lib/backup/dependency.rb
+++ b/lib/backup/dependency.rb
@@ -71,7 +71,7 @@ module Backup
 
         'hipchat' => {
           :require => 'hipchat',
-          :version => '~> 0.4.1',
+          :version => '~> 0.7.0',
           :for => 'Sending notifications to Hipchat'
         },
 


### PR DESCRIPTION
Updated to hipchat 0.7.0.  spec tests pass.
