### PR TITLE
allow hipchat rooms_notified to accept a comma delimited string or array

### DIFF
--- a/lib/backup/notifier/hipchat.rb
+++ b/lib/backup/notifier/hipchat.rb
@@ -83,7 +83,7 @@ module Backup
 
       def send_message(msg, color)
         client = HipChat::Client.new(token)
-        [rooms_notified].flatten.each do |room|
+        Array(rooms_notified).map {|r| r.split(',').map(&:strip) }.flatten.each do |room|
           client[room].send(from, msg, :color => color, :notify => notify_users)
         end
       end


### PR DESCRIPTION
Allow the hipchat configuration to accept both a comma delimited string (new) or array (existing).

This allows more intuitive configuration for a single room such as:
hipchat.rooms_notified = 'room1'

and an easier configuration from puppet by specifying:
hipchat.rooms_notified = 'room1, room2'
