### PR TITLE
allow riak username and group to be specified

### DIFF
--- a/lib/backup/database/riak.rb
+++ b/lib/backup/database/riak.rb
@@ -20,6 +20,14 @@ module Backup
       # Path to riak-admin utility (optional)
       attr_accessor :riak_admin_utility
 
+      ##
+      # Username for the riak instance (optional)
+      attr_accessor :user
+
+      ##
+      # Group for the riak instance (optional)
+      attr_accessor :group
+
       attr_deprecate :utility_path, :version => '3.0.21',
           :message => 'Use Riak#riak_admin_utility instead.',
           :action => lambda {|klass, val| klass.riak_admin_utility = val }
@@ -32,6 +40,8 @@ module Backup
         instance_eval(&block) if block_given?
 
         @riak_admin_utility ||= utility('riak-admin')
+        @user               ||= 'riak'
+        @group              ||= 'riak'
       end
 
       ##
@@ -41,7 +51,7 @@ module Backup
         super
         # have to make riak the owner since the riak-admin tool runs
         # as the riak user in a default setup.
-        FileUtils.chown_R('riak', 'riak', @dump_path)
+        FileUtils.chown_R(@user, @group, @dump_path)
 
         backup_file = File.join(@dump_path, name)
         run("#{ riakadmin } #{ backup_file } node")

--- a/spec/database/riak_spec.rb
+++ b/spec/database/riak_spec.rb
@@ -10,6 +10,8 @@ describe Backup::Database::Riak do
       db.node         = 'riak@localhost'
       db.cookie       = 'riak'
       db.riak_admin_utility = '/path/to/riak-admin'
+      db.user         = 'riak1'
+      db.group        = 'riak1'
     end
   end
 
@@ -36,6 +38,8 @@ describe Backup::Database::Riak do
           db.node.should      == 'riak@localhost'
           db.cookie.should    == 'riak'
           db.riak_admin_utility.should == '/path/to/riak-admin'
+          db.user.should      == 'riak1'
+          db.group.should     == 'riak1'
         end
       end
 
@@ -52,6 +56,8 @@ describe Backup::Database::Riak do
           db.node.should        be_nil
           db.cookie.should      be_nil
           db.riak_admin_utility.should == '/real/riak-admin'
+          db.user.should        == 'riak'
+          db.group.should       == 'riak'
         end
       end
     end # context 'when no pre-configured defaults have been set'
@@ -63,6 +69,8 @@ describe Backup::Database::Riak do
           db.node         = 'db_node'
           db.cookie       = 'db_cookie'
           db.riak_admin_utility = '/default/path/to/riak-admin'
+          db.user         = 'riak2'
+          db.group        = 'riak2'
         end
       end
 
@@ -74,6 +82,8 @@ describe Backup::Database::Riak do
           db.node.should      == 'riak@localhost'
           db.cookie.should    == 'riak'
           db.riak_admin_utility.should == '/path/to/riak-admin'
+          db.user.should      == 'riak1'
+          db.group.should     == 'riak1'
         end
       end
 
@@ -85,6 +95,8 @@ describe Backup::Database::Riak do
           db.node.should        == 'db_node'
           db.cookie.should      == 'db_cookie'
           db.riak_admin_utility.should == '/default/path/to/riak-admin'
+          db.user.should        == 'riak2'
+          db.group.should       == 'riak2'
         end
       end
     end # context 'when no pre-configured defaults have been set'
@@ -104,7 +116,7 @@ describe Backup::Database::Riak do
 
     context 'when no compressor is configured' do
       it 'should only perform the riak-admin backup command' do
-        FileUtils.expects(:chown_R).with('riak', 'riak', '/dump/path')
+        FileUtils.expects(:chown_R).with('riak1', 'riak1', '/dump/path')
         db.expects(:run).in_sequence(s).
             with('riakadmin_command /dump/path/mydatabase node')
 
@@ -119,7 +131,7 @@ describe Backup::Database::Riak do
       end
 
       it 'should compress the backup file and remove the source file' do
-        FileUtils.expects(:chown_R).with('riak', 'riak', '/dump/path')
+        FileUtils.expects(:chown_R).with('riak1', 'riak1', '/dump/path')
         db.expects(:run).in_sequence(s).
             with('riakadmin_command /dump/path/mydatabase node')
         db.expects(:run).in_sequence(s).with(


### PR DESCRIPTION
This patch allows the username and group of the riak database to be supplied.  The default remains 'riak:riak' but there are certain cases where users will have different accounts running the service.  Spec tests updated as well.
