### PR TITLE
Use a new version of fog with support for OpenStack

### DIFF
--- a/lib/backup/dependency.rb
+++ b/lib/backup/dependency.rb
@@ -11,7 +11,7 @@ module Backup
     DEPENDENCIES = {
       'fog' => {
         :require => 'fog',
-        :version => '~> 1.4',
+        :version => '~> 1.10',
         :for     => 'Amazon S3, Rackspace Cloud Files (S3, CloudFiles Storages)',
         :dependencies  => ['net-ssh', 'net-scp']
       },
@@ -31,14 +31,14 @@ module Backup
 
       'net-scp' => {
         :require => 'net/scp',
-        :version => ['>= 1.0.0', '<= 1.0.4'],
+        :version => '~> 1.1.0',
         :for     => 'SCP Protocol (SCP Storage)',
         :dependencies  => 'net-ssh'
       },
 
       'net-ssh' => {
         :require => 'net/ssh',
-        :version => ['>= 2.3.0', '<= 2.5.2'],
+        :version => ['>= 2.6.5', '<= 2.6.6'],
         :for     => 'SSH Protocol (SSH Storage)'
       },
 


### PR DESCRIPTION
This is necessary in order to create an OpenStack storage provider. See the discussion on https://github.com/meskyanichi/backup/pull/402
