### PR TITLE
Add support for SMTP with SSL.

### DIFF
--- a/lib/backup/notifier/mail.rb
+++ b/lib/backup/notifier/mail.rb
@@ -76,6 +76,11 @@ module Backup
       attr_accessor :openssl_verify_mode
 
       ##
+      # Automatically set SSL
+      # Example: true
+      attr_accessor :ssl
+
+      ##
       # When using the `:sendmail` `delivery_method` option,
       # this may be used to specify the absolute path to `sendmail` (if needed)
       # Example: '/usr/sbin/sendmail'
@@ -174,7 +179,8 @@ module Backup
                 :password             => @password,
                 :authentication       => @authentication,
                 :enable_starttls_auto => @enable_starttls_auto,
-                :openssl_verify_mode  => @openssl_verify_mode }
+                :openssl_verify_mode  => @openssl_verify_mode,
+                :ssl                  => @ssl }
             when 'sendmail'
               opts = {}
               opts.merge!(:location  => File.expand_path(@sendmail)) if @sendmail


### PR DESCRIPTION
Fastmail requires SMTP to use SSL but not STARTTLS.  This change enables
ones to turn on SSL without automatically starting TLS.

Here are some relevant links:

http://blog.fastmail.fm/2012/05/21/enforcing-ssltls-encryption-of-all-connections/
https://www.fastmail.fm/docs/encryption.html#ot
