### PR TITLE
fix mongodb compressing output filename confict with multipal mongodb

### DIFF
--- a/lib/backup/database/mongodb.rb
+++ b/lib/backup/database/mongodb.rb
@@ -118,7 +118,7 @@ module Backup
         pipeline  = Pipeline.new
         base_dir  = File.dirname(@dump_path)
         dump_dir  = File.basename(@dump_path)
-        timestamp = Time.now.to_i.to_s[-5, 5]
+        timestamp = Time.now.to_i.to_s[-5, 5] + rand.to_s
         outfile   = @dump_path + '-' + timestamp + '.tar'
 
         Logger.info(


### PR DESCRIPTION
I have multiple mongodb config in one model file, here is my backup output log

[2013/04/11 15:39:36][info]   '/home/xx/Backup/.tmpa_backup_prod/databases/MongoDB'[2013/04/11 15:39:36][info] Using Compressor::Gzip for compression.

[2013/04/11 15:39:36][info]   Command: '/bin/gzip'

[2013/04/11 15:39:36][info]   Ext: '.gz'

[2013/04/11 15:39:36][info] Database::MongoDB completed compressing and packaging:

[2013/04/11 15:39:36][info]   '/home/xx/Backup/.tmp/a_backup_prod/databases/MongoDB-65976.tar.gz'

[2013/04/11 15:39:36][info] Database::MongoDB started dumping and archiving 'uas'.

[2013/04/11 15:39:36][info] Running system utility 'mongodump'...

[2013/04/11 15:39:36][info] mongodump:STDOUT: connected to: localhost:27017

[2013/04/11 15:39:36][info] mongodump:STDOUT: Thu Apr 11 15:39:36 DATABASE: uas      to      /home/xx/Backup/.tmp/a_backup_prod/databases/MongoDB/uas

/home/xx/Backup/.tmp/a_backup_prod/databases/MongoDB/uas/users.metadata.json

[2013/04/11 15:39:36][info] Database::MongoDB started compressing and packaging:

[2013/04/11 15:39:36][info]   '/home/edoctor/Backup/.tmp/zyprexa_backup_prod/databases/MongoDB'

[2013/04/11 15:39:36][info] Using Compressor::Gzip for compression.

[2013/04/11 15:39:36][info]   Command: '/bin/gzip'

[2013/04/11 15:39:36][info]   Ext: '.gz'

[2013/04/11 15:39:36][info] Database::MongoDB completed compressing and packaging:

[2013/04/11 15:39:36][info]   '/home/xx/Backup/.tmpa_backup_prod/databases/MongoDB-65976.tar.gz'

unfortunately they all compressing into one xx.tar.gz file
