### PR TITLE
Elasticsearch Database

### DIFF
--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -62,12 +62,13 @@ module Backup
   ##
   # Autoload Backup database files
   module Database
-    autoload :Base,       File.join(DATABASE_PATH, 'base')
-    autoload :MySQL,      File.join(DATABASE_PATH, 'mysql')
-    autoload :PostgreSQL, File.join(DATABASE_PATH, 'postgresql')
-    autoload :MongoDB,    File.join(DATABASE_PATH, 'mongodb')
-    autoload :Redis,      File.join(DATABASE_PATH, 'redis')
-    autoload :Riak,       File.join(DATABASE_PATH, 'riak')
+    autoload :Base,          File.join(DATABASE_PATH, 'base')
+    autoload :MySQL,         File.join(DATABASE_PATH, 'mysql')
+    autoload :PostgreSQL,    File.join(DATABASE_PATH, 'postgresql')
+    autoload :MongoDB,       File.join(DATABASE_PATH, 'mongodb')
+    autoload :Redis,         File.join(DATABASE_PATH, 'redis')
+    autoload :Riak,          File.join(DATABASE_PATH, 'riak')
+    autoload :Elasticsearch, File.join(DATABASE_PATH, 'elasticsearch')
   end
 
   ##

--- a/lib/backup/config.rb
+++ b/lib/backup/config.rb
@@ -101,7 +101,7 @@ module Backup
         create_modules(
           self,
           [ # Databases
-            ['MySQL', 'PostgreSQL', 'MongoDB', 'Redis', 'Riak'],
+            ['MySQL', 'PostgreSQL', 'MongoDB', 'Redis', 'Riak', 'Elasticsearch'],
             # Storages
             ['S3', 'CloudFiles', 'Ninefold', 'Dropbox', 'FTP',
             'SFTP', 'SCP', 'RSync', 'Local'],

--- a/lib/backup/database/elasticsearch.rb
+++ b/lib/backup/database/elasticsearch.rb
@@ -74,9 +74,13 @@ module Backup
         end
       end
 
+      def backup_all?
+        [:all, ":all", "all"].include?(index)
+      end
+
       def copy!
         src_path = File.join(path, 'nodes/0/indices')
-        src_path = File.join(src_path, index) unless index == :all
+        src_path = File.join(src_path, index) unless backup_all?
         unless File.exist?(src_path)
           raise Errors::Database::Elasticsearch::NotFoundError, <<-EOS
             Elasticsearch index directory not found

--- a/lib/backup/database/elasticsearch.rb
+++ b/lib/backup/database/elasticsearch.rb
@@ -75,7 +75,7 @@ module Backup
       end
 
       def backup_all?
-        [:all, ":all", "all"].include?(index)
+        [:all, ':all', 'all'].include?(index)
       end
 
       def copy!
@@ -87,16 +87,18 @@ module Backup
             Directory path was #{ src_path }
           EOS
         end
-
-        dst_path = File.join(dump_path, dump_filename + '.tar')
-        cmd = "#{ utility(:tar) } -cf - #{ src_path } |"
+        pipeline = Pipeline.new
+        pipeline << "#{ utility(:tar) } -cf - #{ src_path }"
+        dst_ext = '.tar'
         if model.compressor
-          model.compressor.compress_with do |comp_cmd, ext|
-            run("#{ cmd } #{ comp_cmd } > '#{ dst_path + ext }'")
+          model.compressor.compress_with do |cmd, ext|
+            pipeline << cmd
+            dst_ext << ext
           end
-        else
-          run("#{ cmd } #{ utility(:cat) } > '#{ dst_path }'")
         end
+        dst_path = File.join(dump_path, dump_filename + dst_ext)
+        pipeline << "#{ utility(:cat) } > '#{ dst_path }'"
+        pipeline.run
       end
 
     end

--- a/lib/backup/database/elasticsearch.rb
+++ b/lib/backup/database/elasticsearch.rb
@@ -92,10 +92,10 @@ module Backup
         cmd = "#{ utility(:tar) } -cf - #{ src_path } |"
         if model.compressor
           model.compressor.compress_with do |comp_cmd, ext|
-            run("#{ cmd } #{ comp_cmd } -c '#{ src_path }' > '#{ dst_path + ext }'")
+            run("#{ cmd } #{ comp_cmd } > '#{ dst_path + ext }'")
           end
         else
-          run("#{ cmd } > '#{ dst_path }'")
+          run("#{ cmd } #{ utility(:cat) } > '#{ dst_path }'")
         end
       end
 

--- a/lib/backup/database/elasticsearch.rb
+++ b/lib/backup/database/elasticsearch.rb
@@ -153,6 +153,10 @@ module Backup
         dst_path = File.join(dump_path, dump_filename + dst_ext)
         pipeline << "#{ utility(:cat) } > '#{ dst_path }'"
         pipeline.run
+        unless pipeline.success?
+          raise Errors::Database::PipelineError,
+            "Elasticsearch Index '#{ index }' Backup Failed!\n" + pipeline.error_messages
+        end
       end
 
     end

--- a/lib/backup/database/elasticsearch.rb
+++ b/lib/backup/database/elasticsearch.rb
@@ -1,0 +1,99 @@
+# encoding: utf-8
+
+module Backup
+  module Database
+    class Elasticsearch < Base
+
+      ##
+      # Elasticsearch data directory path.
+      #
+      # This is set in `elasticsearch.yml`.
+      #   path:
+      #     data: /var/data/elasticsearch
+      #
+      # eg. /var/data/elasticsearch
+      #
+      attr_accessor :path
+
+      ##
+      # Elasticsearch index name to backup.
+      #
+      # eg. logstash-2013-04-11
+      #
+      attr_accessor :index
+
+      ##
+      # Determines whether Backup should close the index with the
+      # Elasticsearch API before copying the index directory.
+      #
+      attr_accessor :invoke_close
+
+      ##
+      # Elasticsearch API options for the +invoke_close+ option.
+      attr_accessor :host, :port
+
+      def initialize(model, database_id = nil, &block)
+        super
+        instance_eval(&block) if block_given?
+
+        @name ||= 'logstash-' + (Date.today-1).strftime("%Y.%m.%d")
+        @host ||= 'localhost'
+        @port ||= 9200
+      end
+
+      ##
+      # Tars and optionally compresses the Elasticsearch index
+      # folder to the +dump_path+ using the +dump_filename+.
+      #
+      #   <trigger>/databases/Eliasticsearch[-<database_id>].tar[.gz]
+      #
+      # If +invoke_close+ is true, `POST $index/_close` will be invoked.
+      def perform!
+        super
+
+        invoke_close! if invoke_close
+        copy!
+
+        log!(:finished)
+      end
+
+      private
+
+      def close_index_cmd
+        "curl -iXPOST http://#{ host }:#{ port }/#{ index }/_close"
+      end
+
+      def invoke_close!
+        resp = run(close_index_cmd)
+        unless resp =~ /200 OK/
+          raise Errors::Database::Elasticsearch::CommandError, <<-EOS
+            Could not invoke the close index command.
+            Command was: #{ close_index_cmd }
+            Response was: #{ resp }
+          EOS
+        end
+      end
+
+      def copy!
+        src_path = File.join(path, 'nodes/0/indices', index)
+        unless File.exist?(src_path)
+          raise Errors::Database::Elasticsearch::NotFoundError, <<-EOS
+            Elasticsearch index directory not found
+            Folder path was #{ src_path }
+          EOS
+        end
+
+        dst_path = File.join(dump_path, dump_filename + '.tar')
+        cmd = "tar -cf - #{ src_path } |"
+        if model.compressor
+          model.compressor.compress_with do |comp_cmd, ext|
+            run("#{ cmd } #{ comp_cmd } -c '#{ src_path }' > '#{ dst_path + ext }'")
+          end
+        else
+          run("#{ cmd } > '#{ dst_path }'")
+        end
+      end
+
+    end
+  end
+end

--- a/lib/backup/database/elasticsearch.rb
+++ b/lib/backup/database/elasticsearch.rb
@@ -82,7 +82,9 @@ module Backup
         end
         request.body = body
         begin
-          http.request(request)
+          Timeout::timeout(180) do
+            http.request(request)
+          end
         rescue => error
           raise Errors::Database::Elasticsearch::QueryError, <<-EOS
             Could not query the Elasticsearch API.

--- a/spec/database/elasticsearch_spec.rb
+++ b/spec/database/elasticsearch_spec.rb
@@ -1,0 +1,244 @@
+# encoding: utf-8
+
+require File.expand_path('../../spec_helper.rb', __FILE__)
+
+module Backup
+  describe Database::Elasticsearch do
+    let(:model) { Model.new(:test_trigger, 'test label') }
+    let(:db) { Database::Elasticsearch.new(model) }
+    let(:s) { sequence '' }
+
+    it_behaves_like 'a class that includes Configuration::Helpers'
+    it_behaves_like 'a subclass of Database::Base'
+
+    describe '#initialize' do
+      it 'provides default values' do
+        expect( db.path         ).to be_nil
+        expect( db.index        ).to eq :all
+        expect( db.invoke_flush ).to be_nil
+        expect( db.invoke_close ).to be_nil
+        expect( db.host         ).to eq 'localhost'
+        expect( db.port         ).to eq 9200
+      end
+    end # describe '#initialize'
+
+    describe '#perform!' do
+      before do
+        db.expects(:log!).in_sequence(s).with(:started)
+        db.expects(:prepare!).in_sequence(s)
+      end
+
+      specify 'when #invoke_flush is true' do
+        db.invoke_flush = true
+
+        db.expects(:invoke_flush!).in_sequence(s)
+        db.expects(:copy!).in_sequence(s)
+        db.expects(:log!).in_sequence(s).with(:finished)
+
+        db.perform!
+      end
+
+      specify 'when #invoke_flush is false' do
+        db.expects(:invoke_flush!).never
+        db.expects(:copy!).in_sequence(s)
+        db.expects(:log!).in_sequence(s).with(:finished)
+
+        db.perform!
+      end
+
+      specify 'when #invoke_close is true and #index is :all' do
+        db.invoke_close = true
+
+        db.expects(:invoke_close!).never        
+        db.expects(:copy!).in_sequence(s)
+        db.expects(:log!).in_sequence(s).with(:finished)
+
+        db.perform!
+      end
+
+      specify 'when #invoke_close is true and #index is "test"' do
+        db.index = "test"
+        db.invoke_close = true
+
+        db.expects(:invoke_close!).in_sequence(s)
+        db.expects(:copy!).in_sequence(s)
+        db.expects(:log!).in_sequence(s).with(:finished)
+
+        db.perform!
+      end
+      
+      specify 'when #invoke_close is false' do
+        db.expects(:invoke_close!).never
+        db.expects(:copy!).in_sequence(s)
+        db.expects(:log!).in_sequence(s).with(:finished)
+
+        db.perform!
+      end
+    end # describe '#perform!'
+
+    describe '#invoke_flush!' do
+      let(:api_response) do
+        mock('Net::HTTPResponse').stubs(
+          :code => '200',
+          :message => "OK",
+          :content_type => "application/json",
+          :body => ''
+        )
+      end
+
+      before do
+        db.stubs(:api_request).returns(api_response)
+      end
+
+#      specify 'when response is OK' do
+#        db.expects(:run).with('redis_save_cmd').returns('+OK')
+#        db.send(:invoke_flush!)
+#      end
+#
+#      specify 'when response is not OK' do
+#        db.expects(:run).with('redis_save_cmd').returns('No OK Returned')
+#        expect do
+#          db.send(:invoke_save!)
+#        end.to raise_error(Errors::Database::Redis::CommandError) {|err|
+#          expect( err.message ).to match(/Command was: redis_save_cmd/)
+#          expect( err.message ).to match(/Response was: No OK Returned/)
+#        }
+#      end
+    end # describe '#invoke_save!'
+
+#    describe '#copy!' do
+#      before do
+#        db.stubs(:dump_path).returns('/tmp/trigger/databases')
+#        db.path = '/var/lib/redis'
+#      end
+#
+#      context 'when the redis dump file exists' do
+#        before do
+#          File.expects(:exist?).in_sequence(s).with(
+#                                                    '/var/lib/redis/dump.rdb'
+#                                                    ).returns(true)
+#        end
+#
+#        context 'when a compressor is configured' do
+#          let(:compressor) { mock }
+#
+#          before do
+#            model.stubs(:compressor).returns(compressor)
+#            compressor.stubs(:compress_with).yields('cmp_cmd', '.cmp_ext')
+#          end
+#
+#          it 'should copy the redis dump file with compression' do
+#            db.expects(:run).in_sequence(s).with(
+#                                                 "cmp_cmd -c '/var/lib/redis/dump.rdb' > " +
+#                                                 "'/tmp/trigger/databases/Redis.rdb.cmp_ext'"
+#                                                 )
+#            FileUtils.expects(:cp).never
+#
+#            db.send(:copy!)
+#          end
+#        end # context 'when a compressor is configured'
+#
+#        context 'when no compressor is configured' do
+#          it 'should copy the redis dump file without compression' do
+#            FileUtils.expects(:cp).in_sequence(s).with(
+#                                                       '/var/lib/redis/dump.rdb', '/tmp/trigger/databases/Redis.rdb'
+#                                                       )
+#            db.expects(:run).never
+#
+#            db.send(:copy!)
+#          end
+#        end # context 'when no compressor is configured'
+#
+#      end # context 'when the redis dump file exists'
+#
+#      context 'when the redis dump file does not exist' do
+#        it 'raises an error' do
+#          File.expects(:exist?).in_sequence(s).with(
+#                                                    '/var/lib/redis/dump.rdb'
+#                                                    ).returns(false)
+#
+#          expect do
+#            db.send(:copy!)
+#          end.to raise_error(Errors::Database::Redis::NotFoundError)
+#        end
+#      end # context 'when the redis dump file does not exist'
+#
+#    end # describe '#copy!'
+#
+#    describe '#redis_save_cmd' do
+#      let(:option_methods) {%w[
+#      redis_cli_utility password_option connectivity_options user_options
+#    ]}
+#
+#      it 'returns full redis-cli command built from all options' do
+#        option_methods.each {|name| db.stubs(name).returns(name) }
+#        expect( db.send(:redis_save_cmd) ).to eq(
+#                                                 option_methods.join(' ') + ' SAVE'
+#                                                 )
+#      end
+#
+#      it 'handles nil values from option methods' do
+#        option_methods.each {|name| db.stubs(name).returns(nil) }
+#        expect( db.send(:redis_save_cmd) ).to eq(
+#                                                 (' ' * (option_methods.count - 1)) + ' SAVE'
+#                                                 )
+#      end
+#    end # describe '#redis_save_cmd'
+#
+#    describe 'redis_save_cmd option methods' do
+#
+#      describe '#password_option' do
+#        it 'returns argument if specified' do
+#          expect( db.send(:password_option) ).to be_nil
+#
+#          db.password = 'my_password'
+#          expect( db.send(:password_option) ).to eq "-a 'my_password'"
+#        end
+#      end # describe '#password_option'
+#
+#      describe '#connectivity_options' do
+#        it 'returns only the socket argument if #socket specified' do
+#          db.host = 'my_host'
+#          db.port = 'my_port'
+#          db.socket = 'my_socket'
+#          expect( db.send(:connectivity_options) ).to eq(
+#                                                         "-s 'my_socket'"
+#                                                         )
+#        end
+#
+#        it 'returns host and port arguments if specified' do
+#          expect( db.send(:connectivity_options) ).to eq ''
+#
+#          db.host = 'my_host'
+#          expect( db.send(:connectivity_options) ).to eq(
+#                                                         "-h 'my_host'"
+#                                                         )
+#
+#          db.port = 'my_port'
+#          expect( db.send(:connectivity_options) ).to eq(
+#                                                         "-h 'my_host' -p 'my_port'"
+#                                                         )
+#
+#          db.host = nil
+#          expect( db.send(:connectivity_options) ).to eq(
+#                                                         "-p 'my_port'"
+#                                                         )
+#        end
+#      end # describe '#connectivity_options'
+#
+#      describe '#user_options' do
+#        it 'returns arguments for any #additional_options specified' do
+#          expect( db.send(:user_options) ).to eq ''
+#
+#          db.additional_options = ['--opt1', '--opt2']
+#          expect( db.send(:user_options) ).to eq '--opt1 --opt2'
+#
+#          db.additional_options = '--opta --optb'
+#          expect( db.send(:user_options) ).to eq '--opta --optb'
+#        end
+#      end # describe '#user_options'
+#
+#    end # describe 'redis_save_cmd option methods'
+
+  end
+end


### PR DESCRIPTION
This adds a database: "Elasticsearch"

Currently supports tar'n all indices or a specific index (primary goal). I needed to backup yesterdays' Logstash index.

It can flush and/or close an index before backing it up, using the Elasticsearch API. This functionality is exposed via invoke_flush & invoke_close.

Example usage:

https://gist.github.com/portertech/c8cd4ccfa968256cd194

Please let me know your thoughts.
