### PR TITLE
do not sudo if root already (riak backups)

### DIFF
--- a/lib/backup/database/riak.rb
+++ b/lib/backup/database/riak.rb
@@ -61,12 +61,18 @@ module Backup
       # the user running Backup, since the absence of the execute bit on their
       # home directory would deny +user+ access.
       def with_riak_owned_dump_path
-        run("#{ utility(:sudo) } -n #{ utility(:chown) } " +
+        # sudo if not root
+        Config.user == 'root' ? sudo = '' : sudo = "#{ utility(:sudo) } -n "
+
+        run("#{ sudo }#{ utility(:chown) } " +
             "#{ user } '#{ dump_path }'")
         yield
       ensure
         # reclaim ownership
-        run("#{ utility(:sudo) } -n #{ utility(:chown) } -R " +
+
+        # sudo if not root
+        Config.user == 'root' ? sudo = '' : sudo = "#{ utility(:sudo) } -n "
+        run("#{ sudo }#{ utility(:chown) } -R " +
             "#{ Config.user } '#{ dump_path }'")
       end
 


### PR DESCRIPTION
After commit 77e18366 (~3.2.0) where sudo is run on every riak backup I have an issue with my default sudoers (requretty).

Added check to see if we are root already before sudoing and only run sudo if we are not root.
