### PR TITLE
Allow postgresql dump utility to run as different user

### DIFF
--- a/lib/backup/database/postgresql.rb
+++ b/lib/backup/database/postgresql.rb
@@ -15,6 +15,10 @@ module Backup
       attr_accessor :username, :password
 
       ##
+      # If set the pg_dump(all) command is executed as the given user
+      attr_accessor :sudo
+        
+      ##
       # Connectivity options
       attr_accessor :host, :port, :socket
 
@@ -71,12 +75,14 @@ module Backup
 
       def pgdump
         "#{ password_option }" +
+        "#{ sudo_option }" +
         "#{ utility(:pg_dump) } #{ username_option } #{ connectivity_options } " +
         "#{ user_options } #{ tables_to_dump } #{ tables_to_skip } #{ name }"
       end
 
       def pgdumpall
         "#{ password_option }" +
+        "#{ sudo_option }" +
         "#{ utility(:pg_dumpall) } #{ username_option } " +
         "#{ connectivity_options } #{ user_options }"
       end
@@ -85,6 +91,10 @@ module Backup
         "PGPASSWORD='#{ password }' " if password
       end
 
+      def sudo_option
+        "sudo -i -u #{ sudo } " if sudo
+      end
+      
       def username_option
         "--username='#{ username }'" if username
       end


### PR DESCRIPTION
PostgreSQL by default allows password-less access as superuser for the os user `postgres`.
By switching to the user `postgres` the need to specify a password in the backup config or model file can be avoided.
