### PR TITLE
fix issue #370

### DIFF
--- a/lib/backup/database/mysql.rb
+++ b/lib/backup/database/mysql.rb
@@ -87,9 +87,8 @@ module Backup
       end
 
       def connectivity_options
-        return "--socket='#{ socket }'" if socket
-
         opts = []
+        opts << "--socket='#{ socket }'" if socket
         opts << "--host='#{ host }'" if host
         opts << "--port='#{ port }'" if port
         opts.join(' ')


### PR DESCRIPTION
Was not possible to dump mysql remote servers.
It was happening because the host option was being ignored.
