### PR TITLE
Fix "malformed format string" syslog error.

### DIFF
--- a/lib/backup/logger/syslog.rb
+++ b/lib/backup/logger/syslog.rb
@@ -108,7 +108,7 @@ module Backup
       def log(message)
         level = @options.send(message.level)
         ::Syslog.open(@options.ident, @options.options, @options.facility) do |s|
-          message.lines.each {|line| s.log(level, line) }
+          message.lines.each {|line| s.log(level, '%s', line) }
         end
       end
     end

--- a/spec/logger/syslog_spec.rb
+++ b/spec/logger/syslog_spec.rb
@@ -62,10 +62,10 @@ describe Logger::Syslog do
     context 'when sending an :info message' do
       it 'sends info messages to syslog' do
         syslog_logger.expects(:log).in_sequence(s).with(
-          ::Syslog::LOG_INFO, 'message line one'
+          ::Syslog::LOG_INFO, '%s', 'message line one'
         )
         syslog_logger.expects(:log).in_sequence(s).with(
-          ::Syslog::LOG_INFO, 'message line two'
+          ::Syslog::LOG_INFO, '%s', 'message line two'
         )
         Logger.info "message line one\nmessage line two"
       end
@@ -74,10 +74,10 @@ describe Logger::Syslog do
     context 'when sending an :warn message' do
       it 'sends warn messages to syslog' do
         syslog_logger.expects(:log).in_sequence(s).with(
-          ::Syslog::LOG_WARNING, 'message line one'
+          ::Syslog::LOG_WARNING, '%s', 'message line one'
         )
         syslog_logger.expects(:log).in_sequence(s).with(
-          ::Syslog::LOG_WARNING, 'message line two'
+          ::Syslog::LOG_WARNING, '%s', 'message line two'
         )
         Logger.warn "message line one\nmessage line two"
       end
@@ -86,10 +86,10 @@ describe Logger::Syslog do
     context 'when sending an :error message' do
       it 'sends error messages to syslog' do
         syslog_logger.expects(:log).in_sequence(s).with(
-          ::Syslog::LOG_ERR, 'message line one'
+          ::Syslog::LOG_ERR, '%s', 'message line one'
         )
         syslog_logger.expects(:log).in_sequence(s).with(
-          ::Syslog::LOG_ERR, 'message line two'
+          ::Syslog::LOG_ERR, '%s', 'message line two'
         )
         Logger.error "message line one\nmessage line two"
       end


### PR DESCRIPTION
The `Syslog.log` method interprets the second argument as format string.
If a log message contains a "%" character (like mongodump output), an
`ArgumentError` gets raised.

This patch converts the `log` call to use a "%s" format string as second
argument and pass the line as third argument.
