### PR TITLE
Allow Backup to sync remote redis server.

### DIFF
--- a/lib/backup/database/redis.rb
+++ b/lib/backup/database/redis.rb
@@ -63,6 +63,11 @@ module Backup
         super
 
         if use_rdb
+          Logger.configure do
+            ignore_warning(/Transfer finished with success/)
+            ignore_warning(/SYNC sent to master/)
+          end
+
           pipeline = Pipeline.new
 
           pipeline << "#{ basic_redis_cmd } --rdb -"
@@ -86,7 +91,7 @@ module Backup
 
       private
 
-      def error_massage(action, command, response)
+      def error_message(action, command, response)
         <<-EOS
           Could not #{ action }
           Command was: #{ command }
@@ -97,7 +102,7 @@ module Backup
       def invoke_save!
         resp = run(redis_save_cmd)
         unless resp =~ /OK$/
-          raise Error, error_massage("invoke_save", redis_save_cmd, resp)
+          raise Error, error_message("invoke_save", redis_save_cmd, resp)
         end
       end
 


### PR DESCRIPTION
Use `redis-cli --rdb filename` to sync remote redis server and write data to local.

We can then use it like following

``` ruby
database Redis do |db|
    # sync_remote! will dump remote data to the following path/name
    db.name             = "redis_db_name"
    db.path               = "/usr/local/var/db/redis"
    db.password       = "password"

    # If there is no specified host, --rdb will dump local redis-server
    db.host = 33.33.33.10
    db.port = 6379
    db.sync_remote = true
  end
```

Notice that if there is no specified host, `redis-cli --rdb` will dump local redis-server.
In other words, it can somehow replace the function of `redis-cli SAVE`. But i'm not sure whether should we replace `invoke_save!` by `sync_remote!`.

If these codes are OK, I will update README or wiki to add api document later.

This doesn't include a test because I couldn't quite figure out the test suite, but I want to start the conversation.

If there is any concern, please let me know. Thanks!

(related: #340 , #298 )
