### PR TITLE
Splitter suffix length support. 

### DIFF
--- a/lib/backup/model.rb
+++ b/lib/backup/model.rb
@@ -203,14 +203,15 @@ module Backup
 
     ##
     # Adds a Splitter with the given +chunk_size+ in MB.
+	# If specified, the splitter suffix length can be specified (ie. 1 (-a), 2 (-aa), 3 (-aaa) etc).
     # This will split the final backup package into multiple files.
-    def split_into_chunks_of(chunk_size)
-      if chunk_size.is_a?(Integer)
-        @splitter = Splitter.new(self, chunk_size)
+    def split_into_chunks_of(chunk_size, suffix_length = 2)
+      if chunk_size.is_a?(Integer) && suffix_length.is_a?(Integer) && suffix_length > 0
+        @splitter = Splitter.new(self, chunk_size, suffix_length)
       else
         raise Error, <<-EOS
           Invalid Chunk Size for Splitter
-          Argument to #split_into_chunks_of() must be an Integer
+          Argument to #split_into_chunks_of() must be one (or two) Integers for chunk_size and optionally suffix_length > 0
         EOS
       end
     end

--- a/lib/backup/splitter.rb
+++ b/lib/backup/splitter.rb
@@ -4,22 +4,24 @@ module Backup
   class Splitter
     include Backup::Utilities::Helpers
 
-    attr_reader :package, :chunk_size
+    attr_reader :package, :chunk_size, :suffix_length
 
-    def initialize(model, chunk_size)
+    def initialize(model, chunk_size, suffix_length)
       @package = model.package
       @chunk_size = chunk_size
+	    @suffix_length = suffix_length
     end
 
     ##
     # This is called as part of the procedure used to build the final
     # backup package file(s). It yields it's portion of the command line
     # for this procedure, which will split the data being piped into it
-    # into multiple files, based on the @chunk_size.
+    # into multiple files, based on the @chunk_size, using a suffix length as
+	  # specified by @suffix_length.
     # Once the packaging procedure is complete, it will return and
     # @package.chunk_suffixes will be set based on the resulting files.
     def split_with
-      Logger.info "Splitter configured with a chunk size of #{ chunk_size }MB."
+      Logger.info "Splitter configured with a chunk size of #{ chunk_size }MB and suffix length of #{ suffix_length }."
       yield split_command
       after_packaging
     end
@@ -31,9 +33,9 @@ module Backup
     # multiple files, based on the @chunk_size. The files will be
     # written using the given `prefix`, which is the full path to the
     # final @package.basename, plus a '-' separator. This `prefix` will then
-    # be suffixed using 'aa', 'ab', and so on... for each file.
+    # be suffixed using 'aa', 'ab', and so on... (depending of suffix length) for each file.
     def split_command
-      "#{ utility(:split) } -b #{ chunk_size }m - " +
+      "#{ utility(:split) } -a #{ suffix_length } -b #{ chunk_size }m - " +
           "'#{ File.join(Config.tmp_path, package.basename + '-') }'"
     end
 
@@ -41,13 +43,15 @@ module Backup
     # Finds the resulting files from the packaging procedure
     # and stores an Array of suffixes used in @package.chunk_suffixes.
     # If the @chunk_size was never reached and only one file
-    # was written, that file will be suffixed with '-aa'.
-    # In which case, it will simply remove the suffix from the filename.
+    # was written, that file will be suffixed with '-aa' (or -a; -aaa; etc
+	  # depending upon suffix_length). In which case, it will simply
+	  # remove the suffix from the filename.
     def after_packaging
       suffixes = chunk_suffixes
-      if suffixes == ['aa']
+	    first_suffix = 'a' * suffix_length
+	    if suffixes == [first_suffix]
         FileUtils.mv(
-          File.join(Config.tmp_path, package.basename + '-aa'),
+          File.join(Config.tmp_path, "#{ package.basename }-#{ first_suffix }"),
           File.join(Config.tmp_path, package.basename)
         )
       else
@@ -57,7 +61,7 @@ module Backup
 
     ##
     # Returns an array of suffixes for each chunk, in alphabetical order.
-    # For example: [aa, ab, ac, ad, ae]
+    # For example: [aa, ab, ac, ad, ae] or [aaa, aab, aac aad]
     def chunk_suffixes
       chunks.map {|chunk| File.extname(chunk).split('-').last }.sort
     end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -185,7 +185,18 @@ describe 'Backup::Model' do
             instance_eval(&block) if block_given?
           end
         end
-      end
+	    end
+	    module ThreeArgs
+		    class Base
+	        attr_accessor :arg1, :arg2, :arg3, :block_arg
+		      def initialize(arg1, arg2, arg3, &block)
+		        @arg1 = arg1
+		        @arg2 = arg2
+			      @arg3 = arg3
+			      instance_eval(&block) if block_given?
+		      end
+		    end
+	    end
     end
 
     # Set +const+ to +replacement+ for the calling block
@@ -382,22 +393,41 @@ describe 'Backup::Model' do
 
     describe '#split_into_chunks_of' do
       it 'should add a splitter' do
-        using_fake('Splitter', Fake::TwoArgs::Base) do
-          model.split_into_chunks_of(123)
-          model.splitter.should be_an_instance_of Fake::TwoArgs::Base
+        using_fake('Splitter', Fake::ThreeArgs::Base) do
+          model.split_into_chunks_of(123, 2)
+          model.splitter.should be_an_instance_of Fake::ThreeArgs::Base
           model.splitter.arg1.should be(model)
           model.splitter.arg2.should == 123
+		      model.splitter.arg3.should == 2
         end
       end
 
       it 'should raise an error if chunk_size is not an Integer' do
         expect do
-          model.split_into_chunks_of('345')
+          model.split_into_chunks_of('345', 2)
         end.to raise_error {|err|
           err.should be_an_instance_of Backup::Model::Error
-          err.message.should match(/must be an Integer/)
+          err.message.should match(/must be one \(or two\) Integers/)
         }
       end
+
+	    it 'should raise an error if suffix_size is not greater than zero' do
+		    expect do
+		      model.split_into_chunks_of(345, 0)
+		    end.to raise_error {|err|
+		      err.should be_an_instance_of Backup::Model::Error
+		      err.message.should match(/must be one \(or two\) Integers/)
+		    }
+	    end
+
+	    it 'should raise an error if suffix_size is not an Integer' do
+		    expect do
+		      model.split_into_chunks_of(345, '2')
+		    end.to raise_error {|err|
+		      err.should be_an_instance_of Backup::Model::Error
+		      err.message.should match(/must be one \(or two\) Integers/)
+		    }
+	    end
     end
 
   end # describe 'DSL Methods'

--- a/spec/splitter_spec.rb
+++ b/spec/splitter_spec.rb
@@ -6,7 +6,8 @@ module Backup
 describe Splitter do
   let(:model) { Model.new(:test_trigger, 'test label') }
   let(:package) { model.package }
-  let(:splitter) { Splitter.new(model, 250) }
+  let(:splitter) { Splitter.new(model, 250, 2) }
+  let(:splitter_long_suffix) { Splitter.new(model, 250, 3) }
   let(:s) { sequence '' }
 
   before do
@@ -14,12 +15,16 @@ describe Splitter do
   end
 
   # Note: BSD split will not accept a 'M' suffix for the byte size
-  # e.g. split -b 250M
+  # e.g. split -a 2 -b 250M
 
   describe '#initialize' do
     it 'sets instance variables' do
-      expect( splitter.package    ).to be package
-      expect( splitter.chunk_size ).to be 250
+      expect( splitter.package       ).to be package
+      expect( splitter.chunk_size    ).to be 250
+	    expect( splitter.suffix_length ).to be 2
+	    expect( splitter_long_suffix.package       ).to be package
+	    expect( splitter_long_suffix.chunk_size    ).to be 250
+	    expect( splitter_long_suffix.suffix_length ).to be 3
     end
   end
 
@@ -36,11 +41,11 @@ describe Splitter do
 
       it 'updates chunk_suffixes for the package' do
         Logger.expects(:info).in_sequence(s).with(
-          'Splitter configured with a chunk size of 250MB.'
+          'Splitter configured with a chunk size of 250MB and suffix length of 2.'
         )
 
         given_block.expects(:got).in_sequence(s).with(
-          "split -b 250m - '#{ File.join(Config.tmp_path, 'test_trigger.tar-') }'"
+          "split -a 2 -b 250m - '#{ File.join(Config.tmp_path, 'test_trigger.tar-') }'"
         )
 
         FileUtils.expects(:mv).never
@@ -58,11 +63,11 @@ describe Splitter do
 
       it 'removes the suffix from the single file output by split' do
         Logger.expects(:info).in_sequence(s).with(
-          'Splitter configured with a chunk size of 250MB.'
+          'Splitter configured with a chunk size of 250MB and suffix length of 2.'
         )
 
         given_block.expects(:got).in_sequence(s).with(
-          "split -b 250m - '#{ File.join(Config.tmp_path, 'test_trigger.tar-') }'"
+          "split -a 2 -b 250m - '#{ File.join(Config.tmp_path, 'test_trigger.tar-') }'"
         )
 
         FileUtils.expects(:mv).in_sequence(s).with(
@@ -71,6 +76,55 @@ describe Splitter do
         )
 
         splitter.split_with(&block)
+
+        expect( package.chunk_suffixes ).to eq []
+      end
+    end
+
+    context 'when the final package is large enough to be split with non-default suffix length' do
+      before do
+        splitter_long_suffix.stubs(:chunks).returns(
+          ['/tmp/test_trigger.tar-aaa', '/tmp/test_trigger.tar-aab']
+        )
+      end
+
+      it 'updates chunk_suffixes for the package' do
+        Logger.expects(:info).in_sequence(s).with(
+          'Splitter configured with a chunk size of 250MB and suffix length of 3.'
+        )
+
+        given_block.expects(:got).in_sequence(s).with(
+          "split -a 3 -b 250m - '#{ File.join(Config.tmp_path, 'test_trigger.tar-') }'"
+        )
+
+        FileUtils.expects(:mv).never
+
+        splitter_long_suffix.split_with(&block)
+
+        expect( package.chunk_suffixes ).to eq ['aaa', 'aab']
+      end
+    end
+
+    context 'when the final package is not large enough to be split with non-default suffix length' do
+      before do
+        splitter_long_suffix.stubs(:chunks).returns(['/tmp/test_trigger.tar-aaa'])
+      end
+
+      it 'removes the suffix from the single file output by split' do
+        Logger.expects(:info).in_sequence(s).with(
+          'Splitter configured with a chunk size of 250MB and suffix length of 3.'
+        )
+
+        given_block.expects(:got).in_sequence(s).with(
+          "split -a 3 -b 250m - '#{ File.join(Config.tmp_path, 'test_trigger.tar-') }'"
+        )
+
+        FileUtils.expects(:mv).in_sequence(s).with(
+          File.join(Config.tmp_path, 'test_trigger.tar-aaa'),
+          File.join(Config.tmp_path, 'test_trigger.tar')
+        )
+
+        splitter_long_suffix.split_with(&block)
 
         expect( package.chunk_suffixes ).to eq []
       end


### PR DESCRIPTION
For very large backups the default suffix length (2) results in a split error (as the possible suffixes '-aa' to '-zz' can be exhausted). Minor model extension for "split_into_chunks_of" to include additional optional parameter for the split files suffix length.
