### PR TITLE
Don't fail when Fog responds with non-error result

### DIFF
--- a/lib/backup/cloud_io/s3.rb
+++ b/lib/backup/cloud_io/s3.rb
@@ -107,8 +107,9 @@ module Backup
           _keys = keys.slice!(0, 1000)
           with_retries('DELETE Multiple Objects') do
             resp = connection.delete_multiple_objects(bucket, _keys, opts)
-            unless resp.body['DeleteResult'].empty?
-              errors = resp.body['DeleteResult'].map do |result|
+            error_results = resp.body['DeleteResult'].select { |r| r.include?('Error') }
+            unless error_results.empty?
+              errors = error_results.map do |result|
                 error = result['Error']
                 "Failed to delete: #{ error['Key'] }\n" +
                 "Reason: #{ error['Code'] }: #{ error['Message'] }"

--- a/spec/cloud_io/s3_spec.rb
+++ b/spec/cloud_io/s3_spec.rb
@@ -269,6 +269,10 @@ describe CloudIO::S3 do
       )
     }
     let(:resp_ok) { stub(:body => { 'DeleteResult' => [] }) }
+    let(:resp_ok_with_results) {
+      ok_result = { 'Deleted' => { 'Key' => 'key/path' } }
+      stub(:body => { 'DeleteResult' => [ok_result] })
+    }
     let(:resp_bad) {
       stub(:body => {
           'DeleteResult' => [
@@ -351,6 +355,15 @@ describe CloudIO::S3 do
       expect do
         cloud_io.delete(keys_all)
       end.not_to change { keys_all }
+    end
+
+    it 'succeeds with successful results' do
+      cloud_io.expects(:with_retries).with('DELETE Multiple Objects').yields
+      connection.expects(:delete_multiple_objects).with(
+        'my_bucket', ['obj_key_a'], { :quiet => true }
+      ).returns(resp_ok_with_results)
+
+      cloud_io.delete('obj_key_a')
     end
 
     it 'retries on raised errors' do


### PR DESCRIPTION
When calling 'delete_with_multiple_objects', when there are no errors,
Fog can respond with an non-empty DeleteResult array.
Select only error results before deciding whether to fail.
