### PR TITLE
Reduce expected size of riak database backup

### DIFF
--- a/vagrant/spec/acceptance/database/riak_spec.rb
+++ b/vagrant/spec/acceptance/database/riak_spec.rb
@@ -38,7 +38,7 @@ describe 'Database::Riak' do
 
     expect( job.package.exist? ).to be_true
     expect( job.package ).to match_manifest(%q[
-      6500..6700 my_backup/databases/Riak-riak@127.0.0.1.gz
+      6200..6500 my_backup/databases/Riak-riak@127.0.0.1.gz
     ])
   end
 end


### PR DESCRIPTION
```
Failures:

  1) Database::Riak With Compression
     Failure/Error: expect( job.package ).to match_manifest(%q[
       expected that:

       drwxrwxr-x vagrant/vagrant   0 2013-12-03 15:37 my_backup/
       drwxrwxr-x vagrant/vagrant   0 2013-12-03 15:37 my_backup/databases/
       -rw-rw-r-- vagrant/vagrant 6338 2013-12-03 15:37 my_backup/databases/Riak-riak@127.0.0.1.gz

       would match:

             6500..6700 my_backup/databases/Riak-riak@127.0.0.1.gz

     # ./spec/acceptance/database/riak_spec.rb:40:in `block (2 levels) in <module:Backup>'
```
