### PR TITLE
send_nsca.cfg file for nagios notifier

### DIFF
--- a/lib/backup/notifier/nagios.rb
+++ b/lib/backup/notifier/nagios.rb
@@ -13,6 +13,10 @@ module Backup
       attr_accessor :nagios_port
 
       ##
+      # Nagios nrpe configuration file.
+      attr_accessor :send_nsca_cfg     
+ 
+      ##
       # Name of the Nagios service for the backup check.
       attr_accessor :service_name
 
@@ -26,6 +30,7 @@ module Backup
 
         @nagios_host  ||= Config.hostname
         @nagios_port  ||= 5667
+        @send_nsca_cfg||= "/etc/nagios/send_nsca.cfg"
         @service_name ||= "Backup #{ model.trigger }"
         @service_host ||= Config.hostname
       end
@@ -59,7 +64,7 @@ module Backup
       end
 
       def send_message(message)
-        cmd = "#{ utility(:send_nsca) } -H '#{ nagios_host }' -p '#{ nagios_port }'"
+        cmd = "#{ utility(:send_nsca) } -H '#{ nagios_host }' -p '#{ nagios_port }' -c '#{ send_nsca_cfg }'"
         msg = [service_host, service_name, model.exit_status, message].join("\t")
         run("echo '#{ msg }' | #{ cmd }")
       end

--- a/spec/notifier/nagios_spec.rb
+++ b/spec/notifier/nagios_spec.rb
@@ -19,6 +19,7 @@ describe Notifier::Nagios do
     it 'provides default values' do
       expect( notifier.nagios_host  ).to eq 'my.hostname'
       expect( notifier.nagios_port  ).to be 5667
+      expect( notifier.send_nsca_cfg).to eq "/etc/nagios/send_nsca.cfg"
       expect( notifier.service_name ).to eq 'Backup test_trigger'
       expect( notifier.service_host ).to eq 'my.hostname'
 
@@ -33,6 +34,7 @@ describe Notifier::Nagios do
       notifier = Notifier::Nagios.new(model) do |nagios|
         nagios.nagios_host  = 'my_nagios_host'
         nagios.nagios_port  = 1234
+        nagios.send_nsca_cfg= 'my_send_nsca_cfg'
         nagios.service_name = 'my_service_name'
         nagios.service_host = 'my_service_host'
 
@@ -45,6 +47,7 @@ describe Notifier::Nagios do
 
       expect( notifier.nagios_host  ).to eq 'my_nagios_host'
       expect( notifier.nagios_port  ).to be 1234
+      expect( notifier.send_nsca_cfg).to eq 'my_send_nsca_cfg'
       expect( notifier.service_name ).to eq 'my_service_name'
       expect( notifier.service_host ).to eq 'my_service_host'
 
@@ -57,7 +60,7 @@ describe Notifier::Nagios do
   end # describe '#initialize'
 
   describe '#notify!' do
-    let(:nagios_cmd) { "send_nsca -H 'my.hostname' -p '5667'" }
+    let(:nagios_cmd) { "send_nsca -H 'my.hostname' -p '5667' -c '/etc/nagios/send_nsca.cfg'" }
 
     before do
       notifier.service_host = 'my.service.host'


### PR DESCRIPTION
Issue #540 

   send_nsca command takes a -c flag for the location of the send_nsca.cfg file. Without this flag, it assumes the file is in the current directory.
