### PR TITLE
Properly escape special characters in MySQL credentials

### DIFF
--- a/lib/backup/database/mysql.rb
+++ b/lib/backup/database/mysql.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'shellwords'
 
 module Backup
   module Database
@@ -81,8 +82,8 @@ module Backup
 
       def credential_options
         opts = []
-        opts << "--user='#{ username }'" if username
-        opts << "--password='#{ password }'" if password
+        opts << "--user=#{ Shellwords.escape(username) }" if username
+        opts << "--password=#{ Shellwords.escape(password) }" if password
         opts.join(' ')
       end
 

--- a/spec/database/mysql_spec.rb
+++ b/spec/database/mysql_spec.rb
@@ -163,17 +163,25 @@ describe Database::MySQL do
 
         db.username = 'my_user'
         expect( db.send(:credential_options) ).to eq(
-          "--user='my_user'"
+          "--user=my_user"
         )
 
         db.password = 'my_password'
         expect( db.send(:credential_options) ).to eq(
-          "--user='my_user' --password='my_password'"
+          "--user=my_user --password=my_password"
         )
 
         db.username = nil
         expect( db.send(:credential_options) ).to eq(
-          "--password='my_password'"
+          "--password=my_password"
+        )
+      end
+
+      it 'handles special characters' do
+        db.username = "my_user'\""
+        db.password = "my_password'\""
+        expect( db.send(:credential_options) ).to eq(
+          "--user=my_user\\'\\\" --password=my_password\\'\\\""
         )
       end
     end # describe '#credential_options'


### PR DESCRIPTION
Previously the code could handle almost all special characters by surrounding them with a single quotes.
Unfortunately that doesn't work if the credentials contain a single quote.
Ruby already includes the shellwords library which properly escape a string for use in a shell command.
