### PR TITLE
Add support for icon emoji configuration within the Slack notifier

### DIFF
--- a/lib/backup/notifier/slack.rb
+++ b/lib/backup/notifier/slack.rb
@@ -23,6 +23,14 @@ module Backup
       attr_accessor :username
 
       ##
+      # The emoji icon to display along with the notification
+      #
+      # See http://www.emoji-cheat-sheet.com for a list of icons.
+      #
+      # Default: :floppy_disk:
+      attr_accessor :icon_emoji
+
+      ##
       # Array of statuses for which the log file should be attached.
       #
       # Available statuses are: `:success`, `:warning` and `:failure`.
@@ -34,6 +42,7 @@ module Backup
         instance_eval(&block) if block_given?
 
         @send_log_on ||= [:warning, :failure]
+        @icon_emoji  ||= ':floppy_disk:'
       end
 
       private
@@ -64,7 +73,7 @@ module Backup
         message = "#{ tag } #{ model.label } (#{ model.trigger })"
 
         data = { :text => message }
-        [:channel, :username].each do |param|
+        [:channel, :username, :icon_emoji].each do |param|
           val = send(param)
           data.merge!(param => val) if val
         end

--- a/spec/notifier/slack_spec.rb
+++ b/spec/notifier/slack_spec.rb
@@ -12,24 +12,26 @@ describe Notifier::Slack do
 
   describe '#initialize' do
     it 'provides default values' do
-      expect( notifier.team     ).to be_nil
-      expect( notifier.token    ).to be_nil
-      expect( notifier.channel  ).to be_nil
-      expect( notifier.username ).to be_nil
+      expect( notifier.team       ).to be_nil
+      expect( notifier.token      ).to be_nil
+      expect( notifier.channel    ).to be_nil
+      expect( notifier.username   ).to be_nil
+      expect( notifier.icon_emoji ).to eq(':floppy_disk:')
 
-      expect( notifier.on_success     ).to be(true)
-      expect( notifier.on_warning     ).to be(true)
-      expect( notifier.on_failure     ).to be(true)
-      expect( notifier.max_retries    ).to be(10)
-      expect( notifier.retry_waitsec  ).to be(30)
+      expect( notifier.on_success    ).to be(true)
+      expect( notifier.on_warning    ).to be(true)
+      expect( notifier.on_failure    ).to be(true)
+      expect( notifier.max_retries   ).to be(10)
+      expect( notifier.retry_waitsec ).to be(30)
     end
 
     it 'configures the notifier' do
       notifier = Notifier::Slack.new(model) do |slack|
-        slack.team     = 'my_team'
-        slack.token    = 'my_token'
-        slack.channel  = 'my_channel'
-        slack.username = 'my_username'
+        slack.team       = 'my_team'
+        slack.token      = 'my_token'
+        slack.channel    = 'my_channel'
+        slack.username   = 'my_username'
+        slack.icon_emoji = ':vhs:'
 
         slack.on_success     = false
         slack.on_warning     = false
@@ -39,10 +41,11 @@ describe Notifier::Slack do
       end
 
 
-      expect( notifier.team     ).to eq 'my_team'
-      expect( notifier.token    ).to eq 'my_token'
-      expect( notifier.channel  ).to eq 'my_channel'
-      expect( notifier.username ).to eq 'my_username'
+      expect( notifier.team       ).to eq 'my_team'
+      expect( notifier.token      ).to eq 'my_token'
+      expect( notifier.channel    ).to eq 'my_channel'
+      expect( notifier.username   ).to eq 'my_username'
+      expect( notifier.icon_emoji ).to eq ':vhs:'
 
       expect( notifier.on_success     ).to be(false)
       expect( notifier.on_warning     ).to be(false)
@@ -124,19 +127,21 @@ describe Notifier::Slack do
     context 'when optional parameters are provided' do
       let(:notifier) {
         Notifier::Slack.new(model) do |slack|
-          slack.team     = 'my_team'
-          slack.token    = 'my_token'
-          slack.channel  = 'my_channel'
-          slack.username = 'my_username'
+          slack.team       = 'my_team'
+          slack.token      = 'my_token'
+          slack.channel    = 'my_channel'
+          slack.username   = 'my_username'
+          slack.icon_emoji = ':vhs:'
         end
       }
 
       it 'sends message with optional parameters' do
         Excon.expects(:post).with() do |_url, options|
           expected_excon_params(_url, options, {
-            :text     => "[Backup::Success] test label (test_trigger)",
-            :channel  => 'my_channel',
-            :username => 'my_username'
+            :text       => "[Backup::Success] test label (test_trigger)",
+            :channel    => 'my_channel',
+            :username   => 'my_username',
+            :icon_emoji => ':vhs:'
           })
         end
 


### PR DESCRIPTION
By default, incoming Slack webhooks are displayed with the generic webhook emoji:

![incoming_webhook_example1](https://cloud.githubusercontent.com/assets/123595/3912368/42d893dc-232a-11e4-86e8-a9fb81f6dddf.png)

This PR exposes a new `icon_emoji` attribute on the Slack notifier:

``` ruby
notify_by Slack do |slack|
  slack.icon_emoji = ':ghost:'
end
```

![incoming_webhook_example3](https://cloud.githubusercontent.com/assets/123595/3912367/42d7e4f0-232a-11e4-8c87-d58eef248590.png)
