### PR TITLE
Add backtraces to non-Backup::Error errors in CLI calls

### DIFF
--- a/lib/backup/cli.rb
+++ b/lib/backup/cli.rb
@@ -142,6 +142,9 @@ module Backup
 
       rescue Exception => err
         Logger.error Error.wrap(err)
+        unless Helpers.is_backup_error? err
+          Logger.error err.backtrace.join("\n")
+        end
         # Logger configuration will be ignored
         # and messages will be output to the console only.
         Logger.abort!
@@ -219,6 +222,9 @@ module Backup
         Config.load(options)
       rescue Exception => err
         Logger.error Error.wrap(err)
+        unless Helpers.is_backup_error? err
+          Logger.error err.backtrace.join("\n")
+        end
       end
 
       if Logger.has_warnings? || Logger.has_errors?
@@ -355,6 +361,10 @@ module Backup
         def exec!(cmd)
           puts "Launching: #{ cmd }"
           exec(cmd)
+        end
+
+        def is_backup_error?(error)
+          error.class.ancestors.include? Backup::Error
         end
 
       end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -204,9 +204,16 @@ describe 'Backup::CLI' do
 
         it 'aborts with status code 3 and logs messages to the console only' do
 
-          Backup::Logger.expects(:error).in_sequence(s).with do |err|
-            err.should be_a(Backup::CLI::Error)
-            err.message.should match(/config load error/)
+          expectations = [
+            Proc.new { |err|
+              err.should be_a(Backup::CLI::Error)
+              err.message.should match(/config load error/)
+            },
+            Proc.new { |err| err.should be_a(String) }
+          ]
+          Backup::Logger.expects(:error).in_sequence(s).times(2).with do |err|
+            expectation = expectations.shift
+            expectation.call(err) if expectation
           end
 
           Backup::Logger.expects(:abort!).in_sequence(s)


### PR DESCRIPTION
Add support for backtraces on non-`Backup::Error` errors in CLI calls. See also #571

Example without backtraces:

``` sh
$ bundle exec backup check
[2014/08/25 19:45:06][error] CLI::Error
[2014/08/25 19:45:06][error] --- Wrapped Exception ---
[2014/08/25 19:45:06][error] TypeError: no implicit conversion of Symbol into String
[2014/08/25 19:45:06][error] Configuration Check Failed.
```

Example with backtraces as per this PR:

``` sh
$ bundle exec backup check
[2014/08/25 19:44:03][error] CLI::Error
[2014/08/25 19:44:03][error] --- Wrapped Exception ---
[2014/08/25 19:44:03][error] TypeError: no implicit conversion of Symbol into String
[2014/08/25 19:44:03][error] /Users/tom/projects/backup/lib/backup/cli.rb:222:in `check'
[2014/08/25 19:44:03][error] /Users/tom/.gem/ruby/2.1.2/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
[2014/08/25 19:44:03][error] /Users/tom/.gem/ruby/2.1.2/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
[2014/08/25 19:44:03][error] /Users/tom/.gem/ruby/2.1.2/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
[2014/08/25 19:44:03][error] /Users/tom/.gem/ruby/2.1.2/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
[2014/08/25 19:44:03][error] /Users/tom/projects/backup/bin/backup:5:in `<top (required)>'
[2014/08/25 19:44:03][error] /Users/tom/.gem/ruby/2.1.2/bin/backup:23:in `load'
[2014/08/25 19:44:03][error] /Users/tom/.gem/ruby/2.1.2/bin/backup:23:in `<main>'
[2014/08/25 19:44:03][error] Configuration Check Failed.
```

My only problem is with the specs. I don't use Mocha ever so the expectations on method calls was a bit of an experience. Does anyone have any insight in this and can review if I am doing it the right way? @tomash  perhaps?
