### PR TITLE
Sqlite database does not respect database_id

### DIFF
--- a/templates/cli/databases/sqlite
+++ b/templates/cli/databases/sqlite
@@ -2,9 +2,9 @@
   # SQLite [Database]
   #
   database SQLite do |db|
-    # To dump all databases, set `db.name = :all` (or leave blank)
-    db.name               = "my_database_name"
-    db.path               = "/path/to/my/sqlite/db"
+    # Database name and path
+    db.name               = "my_database_name.sqlite3"
+    db.path               = "/path/to/my/sqlite/db/"
 
     # Optional: Use to set the location of this utility
     #   if it cannot be found by name in your $PATH


### PR DESCRIPTION
Databases should be exported as `databases/SQLite-my_id.sql` , given `database SQLite, :my_id do |db|`
It incorrectly exported as `databases/something.sql` , where `something` was the filename.  This leads to backups of databases being overwritten if they have the same name.
This commit also simplifies the model, by relating one model to one file.
