### PR TITLE
Hash#each_key instead of Hash#keys.each. Faster code.

### DIFF
--- a/spec/syncer/cloud/local_file_spec.rb
+++ b/spec/syncer/cloud/local_file_spec.rb
@@ -29,7 +29,7 @@ describe Syncer::Cloud::LocalFile do
           'base_dir.file'               => 'a6cfa67bfa0e16402b76d4560c0baa3d' }
       }
       before do
-        test_files.keys.each do |path|
+        test_files.each_key do |path|
           File.open(File.join(@tmpdir, path), 'w') {|file| file.write path }
         end
       end

--- a/vagrant/utils/tasks/mongodb.rake
+++ b/vagrant/utils/tasks/mongodb.rake
@@ -53,7 +53,7 @@ module MongoDBTask
 
     def drop_all
       puts 'Dropping Databases...'
-      DATABASES.keys.each do |db_name|
+      DATABASES.each_key do |db_name|
         mongo_client.drop_database db_name.to_s
       end
     end

--- a/vagrant/utils/tasks/mysql.rake
+++ b/vagrant/utils/tasks/mysql.rake
@@ -40,7 +40,7 @@ module MySQLTask
     def drop_all
       puts 'Dropping Databases...'
       connection = connect_to(nil)
-      DATABASES.keys.each do |db_name|
+      DATABASES.each_key do |db_name|
         connection.drop_database db_name
       end
     end

--- a/vagrant/utils/tasks/postgresql.rake
+++ b/vagrant/utils/tasks/postgresql.rake
@@ -38,7 +38,7 @@ module PostgreSQLTask
     def drop_all
       puts 'Dropping Databases...'
       connection = connect_to(nil)
-      DATABASES.keys.each do |db_name|
+      DATABASES.each_key do |db_name|
         connection.drop_database db_name
       end
     end


### PR DESCRIPTION
More info at https://github.com/JuanitoFatas/fast-ruby#hasheach_key-instead-of-hashkeyseach-code.

Hash#keys creates new array and then you call #each on that array, while #each_key iterates over hash keys without creating new objects.
