### PR TITLE
provide option to disable apply log for innobackupex

### DIFF
--- a/lib/backup/database/mysql.rb
+++ b/lib/backup/database/mysql.rb
@@ -47,6 +47,12 @@ module Backup
       attr_accessor :backup_engine
 
       ##
+      # If true (which is the default behaviour), the backup will be prepared
+      # after it has been successfuly created. This option is only valid if
+      # :backup_engine is set to :innobackupex.
+      attr_accessor :prepare_backup
+
+      ##
       # If set the backup engine command block is executed as the given user
       attr_accessor :sudo_user
 
@@ -60,6 +66,7 @@ module Backup
 
         @name ||= :all
         @backup_engine ||= :mysqldump
+        @prepare_backup = true if @prepare_backup.nil?
       end
 
       ##
@@ -151,12 +158,17 @@ module Backup
         "#{ utility(:innobackupex) } #{ credential_options } " +
         "#{ connectivity_options } #{ user_options } " +
         "--no-timestamp #{ temp_dir } #{ quiet_option } && " +
-        # Log applying phase (prepare for restore)
-        "#{ utility(:innobackupex) } --apply-log #{ temp_dir } " +
-        "#{ user_prepare_options }  #{ quiet_option } && " +
+        innobackupex_prepare +
         # Move files to tar-ed stream on stdout
         "#{ utility(:tar) } --remove-files -cf -  " +
         "-C #{ File.dirname(temp_dir) } #{ File.basename(temp_dir) }"
+      end
+
+      def innobackupex_prepare
+        return "" unless @prepare_backup
+        # Log applying phase (prepare for restore)
+        "#{ utility(:innobackupex) } --apply-log #{ temp_dir } " +
+        "#{ user_prepare_options }  #{ quiet_option } && "
       end
 
       def sudo_option(command_block)

--- a/spec/database/mysql_spec.rb
+++ b/spec/database/mysql_spec.rb
@@ -37,6 +37,7 @@ describe Database::MySQL do
       expect( db.prepare_options    ).to be_nil
       expect( db.sudo_user          ).to be_nil
       expect( db.backup_engine      ).to eq :mysqldump
+      expect( db.prepare_backup     ).to be_true
     end
 
     it 'configures the database' do
@@ -53,6 +54,7 @@ describe Database::MySQL do
         mysql.prepare_options    = 'my_prepare_options'
         mysql.sudo_user          = 'my_sudo_user'
         mysql.backup_engine      = 'my_backup_engine'
+        mysql.prepare_backup     = false
       end
 
       expect( db.database_id        ).to eq 'my_id'
@@ -69,6 +71,7 @@ describe Database::MySQL do
       expect( db.sudo_user          ).to eq 'my_sudo_user'
       expect( db.backup_engine      ).to eq 'my_backup_engine'
       expect( db.verbose            ).to be_false
+      expect( db.prepare_backup     ).to be_false
     end
   end # describe '#initialize'
 
@@ -440,6 +443,19 @@ describe Database::MySQL do
           "tar --remove-files -cf - -C /tmp MySQL.bkpdir"
         )
       end
+    end
+
+    context "with prepare_backup option disabled" do
+      before do
+        db.prepare_backup = false
+      end
+
+      it "does not contain apply-log command" do
+        expect( db.send(:innobackupex).split.join(" ") ).to eq(
+          "innobackupex --no-timestamp /tmp/MySQL.bkpdir 2> /dev/null && " +
+          "tar --remove-files -cf - -C /tmp MySQL.bkpdir"
+        )
+      end      
     end
   end
 


### PR DESCRIPTION
I think it would be a good idea to let the user decide if he wants to apply the logs before the backup is stored. Disabling the apply log command reduces the required disc space considerably.

I tried to provide tests as much as possible but I don't get all of the tests running. I always get following two errors

```
[rebuy-dev@localhost backupv4]$ bundle exec rspec spec

Ruby version: ruby 1.9.3p547 (2014-05-14 revision 45962) [x86_64-linux]

Run options: include {:focus=>true}                                                                                                                                                                          

All examples were filtered out; ignoring {:focus=>true}
  1) Backup::Database::MySQL behaves like a class that includes Config::Helpers setting defaults allows accessors to be configured with default values                                                       
     Failure/Error: expect( klass.send(name) ).to eq expected

       expected: "default_prepare_backup"
            got: false

       (compared using ==)
     Shared Example Group: "a class that includes Config::Helpers" called from ./spec/database/mysql_spec.rb:22
     # ./spec/support/shared_examples/config_defaults.rb:31:in `block (4 levels) in <top (required)>'
     # ./spec/support/shared_examples/config_defaults.rb:29:in `each'
     # ./spec/support/shared_examples/config_defaults.rb:29:in `block (3 levels) in <top (required)>'

  2) Backup::Database::MySQL behaves like a class that includes Config::Helpers setting defaults allows defaults to be overridden                                                                            
     Failure/Error: expect( klass.send(name) ).to eq expected

       expected: "new_prepare_backup"
            got: false

       (compared using ==)
     Shared Example Group: "a class that includes Config::Helpers" called from ./spec/database/mysql_spec.rb:22
     # ./spec/support/shared_examples/config_defaults.rb:48:in `block (4 levels) in <top (required)>'
     # ./spec/support/shared_examples/config_defaults.rb:46:in `each'
     # ./spec/support/shared_examples/config_defaults.rb:46:in `block (3 levels) in <top (required)>'

 1342/1342 |===================================================================================== 100 =====================================================================================>| Time: 00:00:05 

Finished in 5.76 seconds
1342 examples, 2 failures
```

Since I'm not too much into ruby and I don't want to spend time on something you can most likely answer in a second, I'd love to hear what I've to change to get these tests running

Best regards,
Daniel
