### PR TITLE
Add webhook config for Slack

### DIFF
--- a/lib/backup/notifier/slack.rb
+++ b/lib/backup/notifier/slack.rb
@@ -7,12 +7,8 @@ module Backup
     class Slack < Base
 
       ##
-      # The Team name
-      attr_accessor :team
-
-      ##
-      # The Integration Token
-      attr_accessor :token
+      # The incoming webhook url
+      attr_accessor :webhook_url
 
       ##
       # The channel to send messages to
@@ -151,7 +147,7 @@ module Backup
       end
 
       def uri
-        @uri ||= "https://#{team}.slack.com/services/hooks/incoming-webhook?token=#{token}"
+        @uri ||= webhook_url
       end
     end
   end

--- a/templates/cli/notifiers/slack
+++ b/templates/cli/notifiers/slack
@@ -6,11 +6,10 @@
     slack.on_warning = true
     slack.on_failure = true
 
-    # The team name
-    slack.team = 'my_team'
+    # The incoming webhook url
+    # https://hooks.slack.com/services/xxxxxxxx/xxxxxxxxx/xxxxxxxxxx
+    slack.webhook_url = 'xxxxxxxxxxxxxxxxxxxxxxxx'
 
-    # The integration token
-    slack.token = 'xxxxxxxxxxxxxxxxxxxxxxxx'
 
     ##
     # Optional


### PR DESCRIPTION
Slack have changed the way they deal with webhook calls.

Instead of `https://#{team}.slack.com/services/hooks/incoming-webhook?token=#{token}` they now generate unique webhook url for each (webhook) integration.
