### PR TITLE
Update to fog 1.25 gem to support AWS4.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.2.8)
     addressable (2.3.5)
     atomic (1.1.14)
     aws-ses (0.5.0)
@@ -20,24 +21,70 @@ GEM
     dropbox-sdk (1.5.1)
       json
     equalizer (0.0.9)
-    excon (0.31.0)
+    excon (0.42.1)
     faraday (0.8.8)
       multipart-post (~> 1.2.0)
     ffi (1.9.3)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
     flowdock (0.4.0)
       httparty (~> 0.7)
       multi_json
-    fog (1.19.0)
+    fog (1.25.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.25)
+      fog-json
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-sakuracloud (>= 0.0.4)
+      fog-softlayer
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+      opennebula
+    fog-brightbox (0.7.1)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-core (1.25.0)
       builder
-      excon (~> 0.31.0)
-      formatador (~> 0.2.0)
+      excon (~> 0.38)
+      formatador (~> 0.2)
       mime-types
-      multi_json (~> 1.0)
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
-      nokogiri (~> 1.5)
-      ruby-hmac
-    formatador (0.2.4)
+    fog-json (1.0.0)
+      multi_json (~> 1.0)
+    fog-profitbricks (0.0.1)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-radosgw (0.0.3)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-sakuracloud (0.1.1)
+      fog-core
+      fog-json
+    fog-softlayer (0.3.25)
+      fog-core
+      fog-json
+    fog-terremark (0.0.3)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.0.1)
+      fission
+      fog-core
+    fog-voxel (0.0.2)
+      fog-core
+      fog-xml
+    fog-xml (0.1.1)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
     fuubar (1.3.2)
       rspec (>= 2.14.0, < 3.1.0)
       ruby-progressbar (~> 1.3)
@@ -58,6 +105,8 @@ GEM
     httparty (0.12.0)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
+    inflecto (0.0.2)
+    ipaddress (0.8.0)
     json (1.8.1)
     listen (2.4.0)
       celluloid (>= 0.15.2)
@@ -72,20 +121,24 @@ GEM
     metaclass (0.0.1)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mini_portile (0.5.2)
+    mini_portile (0.6.1)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
-    multi_json (1.8.2)
+    multi_json (1.10.1)
     multi_xml (0.5.5)
     multipart-post (1.2.0)
-    net-scp (1.1.2)
+    net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (2.7.0)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
+    net-ssh (2.9.1)
+    nokogiri (1.6.5)
+      mini_portile (~> 0.6.0)
     open4 (1.3.0)
+    opennebula (4.10.1)
+      json
+      nokogiri
+      rbvmomi
     pagerduty (2.0.0)
       json (>= 1.7.7)
     polyglot (0.3.3)
@@ -96,6 +149,10 @@ GEM
     rb-fsevent (0.9.4)
     rb-inotify (0.9.3)
       ffi (>= 0.5.0)
+    rbvmomi (1.8.2)
+      builder
+      nokogiri (>= 1.4.1)
+      trollop
     redcarpet (3.0.0)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -105,7 +162,6 @@ GEM
     rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.4)
-    ruby-hmac (0.4.0)
     ruby-progressbar (1.4.0)
     simple_oauth (0.2.0)
     slop (3.4.7)
@@ -117,6 +173,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
+    trollop (2.0)
     twitter (5.5.0)
       addressable (~> 2.3)
       buftok (~> 0.2.0)


### PR DESCRIPTION
Firstly, this is an awesome gem.
For fog, see https://github.com/fog/fog/blob/master/CHANGELOG.md : version 1.25 is needed if you want to use the new locations like Frankfurt, as they ONLY support AWS v4 and up.
Locally I changed my gemfile.lock to test with the backup gem and a Frankfurt Amazon bucket. Everything works as expected.
