### PR TITLE
dropbox db:path issue fix

### DIFF
--- a/lib/backup/storage/dropbox.rb
+++ b/lib/backup/storage/dropbox.rb
@@ -56,7 +56,6 @@ module Backup
         @chunk_size     ||= 4 # MiB
         @max_retries    ||= 10
         @retry_waitsec  ||= 30
-        path.sub!(/^\//, '')
       end
 
       private


### PR DESCRIPTION
In the /lib/backup/storage/dropbox.rb file line 59 is removing the first character of the storage path. So absoulate link path does not work. For example if I set db.path        = "/path/to/my/backups" It will read as
~/path/to/my/backups But It does not store the file there either and fails to upload. I had to set db.path        = "//path/to/my/backups" (needed to use double slash) to set the proper absoulate path
