### PR TITLE
Remove unf_ext dependency

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -98,6 +98,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'treetop', '= 1.4.15'
   gem.add_dependency 'twitter', '= 5.5.0'
   gem.add_dependency 'unf', '= 0.1.3'
-  gem.add_dependency 'unf_ext', '= 0.0.6'
   gem.add_dependency 'xml-simple', '= 1.1.4'
 end


### PR DESCRIPTION
`unf_ext` is not needed, because unf requires it internally when the ruby platform is CRuby.
This will make the gem compatible with jruby. Because currently the hard dependency on `unf_ext` breaks it.

More info [here](https://github.com/knu/ruby-unf#description)