### PR TITLE
Properly escape passwords when passing to openssl

### DIFF
--- a/lib/backup/encryptor/open_ssl.rb
+++ b/lib/backup/encryptor/open_ssl.rb
@@ -62,8 +62,13 @@ module Backup
         opts = ['aes-256-cbc']
         opts << '-base64' if @base64
         opts << '-salt'   if @salt
-        opts << ( @password_file.to_s.empty? ?
-                "-k '#{@password}'" : "-pass file:#{@password_file}" )
+
+        if @password_file.to_s.empty?
+          opts << "-k #{Shellwords.escape(@password)}"
+        else
+          opts << "-pass file:#{@password_file}"
+        end
+
         opts.join(' ')
       end
 

--- a/spec/encryptor/open_ssl_spec.rb
+++ b/spec/encryptor/open_ssl_spec.rb
@@ -117,11 +117,11 @@ describe Backup::Encryptor::OpenSSL do
     end
 
     context 'when #password is given (without #password_file given)' do
-      before { encryptor.password = 'password' }
+      before { encryptor.password = %q(pa\ss'w"ord) }
 
       it 'should include the given password in the #password option' do
         encryptor.send(:options).should ==
-            "aes-256-cbc -k 'password'"
+            %q(aes-256-cbc -k pa\\\ss\'w\"ord)
       end
     end
 


### PR DESCRIPTION
This ensures that the single quote character `'` can be used in an `Encryptor::OpenSSL` password.

Fixes this bug:

```
[2015/04/08 17:17:55][info] Using Encryptor::OpenSSL to encrypt the archive.
[2015/04/08 17:17:55][warn]   Pipeline STDERR Messages:
[2015/04/08 17:17:55][warn]   (Note: may be interleaved if multiple commands returned error messages)
[2015/04/08 17:17:55][warn] 
[2015/04/08 17:17:55][warn]   sh: 1: Syntax error: Unterminated quoted string
```