### PR TITLE
Command notifier

### DIFF
--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -116,6 +116,7 @@ module Backup
     autoload :Zabbix,    File.join(NOTIFIER_PATH, 'zabbix')
     autoload :DataDog,   File.join(NOTIFIER_PATH, 'datadog')
     autoload :Ses,       File.join(NOTIFIER_PATH, 'ses')
+    autoload :Command,   File.join(NOTIFIER_PATH, 'command')
   end
 
   ##

--- a/lib/backup/config/dsl.rb
+++ b/lib/backup/config/dsl.rb
@@ -43,7 +43,7 @@ module Backup
               # Notifiers
               ['Mail', 'Twitter', 'Campfire', 'Prowl',
               'Hipchat', 'PagerDuty', 'Pushover', 'HttpPost', 'Nagios',
-              'Slack', 'FlowDock', 'Zabbix', 'Ses', 'DataDog']
+              'Slack', 'FlowDock', 'Zabbix', 'Ses', 'DataDog', 'Command']
             ]
           )
         end

--- a/lib/backup/notifier/command.rb
+++ b/lib/backup/notifier/command.rb
@@ -22,6 +22,7 @@ module Backup
       # In strings you can use the following placeholders:
       #
       # %l - Model label
+      # %t - Model trigger
       # %s - Status (success/failure/warning)
       # %v - Status verb (succeeded/failed/succeeded with warnings)
       #
@@ -71,7 +72,7 @@ module Backup
                   when "l"
                     model.label
                   when "t"
-                    model.trigger
+                    model.trigger.to_s
                   when "v"
                     status_verb(status)
                   when "s"

--- a/lib/backup/notifier/command.rb
+++ b/lib/backup/notifier/command.rb
@@ -1,0 +1,98 @@
+# encoding: utf-8
+
+module Backup
+  module Notifier
+    class Command < Base
+
+      ##
+      # Command to execute.
+      #
+      # Make sure it is accessible from your $PATH, or provide
+      # the absolute path to the command.
+      attr_accessor :command
+
+      ##
+      # Arguments to pass to the command.
+      #
+      # Must be an array of strings or callable objects.
+      #
+      # Callables will be invoked with #call(model, status),
+      # and the return value used as the argument.
+      #
+      # In strings you can use the following placeholders:
+      #
+      # %l - Model label
+      # %s - Status (success/failure/warning)
+      # %v - Status verb (succeeded/failed/succeeded with warnings)
+      #
+      # All placeholders can be used with uppercase letters to capitalize
+      # the value.
+      #
+      # Defaults to ["%L %v"]
+      attr_accessor :args
+
+      def initialize(model, &block)
+        super
+        instance_eval(&block) if block_given?
+
+        @args ||= ["%L %v"]
+      end
+
+      private
+
+      ##
+      # Notify the user of the backup operation results.
+      #
+      # `status` indicates one of the following:
+      #
+      # `:success`
+      # : The backup completed successfully.
+      # : Notification will be sent if `on_success` is `true`.
+      #
+      # `:warning`
+      # : The backup completed successfully, but warnings were logged.
+      # : Notification will be sent if `on_warning` or `on_success` is `true`.
+      #
+      # `:failure`
+      # : The backup operation failed.
+      # : Notification will be sent if `on_warning` or `on_success` is `true`.
+      #
+      def notify!(status)
+        IO.popen([@command] + args.map { |arg| format_arg(arg, status) })
+      end
+
+      def format_arg(arg, status)
+        if arg.respond_to?(:call)
+          arg.call(model, status)
+        else
+          arg.gsub(/%(\w)/) do |match|
+            ph = match[1]
+            val = case ph.downcase
+                  when "l"
+                    model.label
+                  when "t"
+                    model.trigger
+                  when "v"
+                    status_verb(status)
+                  when "s"
+                    status.to_s
+                  end
+            val.capitalize! if ph == ph.upcase
+            val
+          end
+        end
+      end
+
+      def status_verb(status)
+        case status
+        when :success
+          "succeeded"
+        when :failure
+          "failed"
+        when :warning
+          "succeeded with warnings"
+        end
+      end
+    end
+  end
+end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -561,7 +561,7 @@ describe 'Backup::CLI' do
         syncers (cloud_files, rsync_local, rsync_pull, rsync_push, s3)
         encryptor (gpg, openssl)
         compressor (bzip2, custom, gzip)
-        notifiers (campfire, datadog, flowdock, hipchat, http_post, mail, nagios, pagerduty, prowl, pushover, ses, slack, twitter)
+        notifiers (campfire, command, datadog, flowdock, hipchat, http_post, mail, nagios, pagerduty, prowl, pushover, ses, slack, twitter)
       EOS
 
       out, err = capture_io do

--- a/spec/notifier/command_notifier_spec.rb
+++ b/spec/notifier/command_notifier_spec.rb
@@ -1,0 +1,85 @@
+# encoding: utf-8
+
+require File.expand_path('../../spec_helper.rb', __FILE__)
+
+module Backup
+describe Notifier::Command do
+  let(:model) { Model.new(:test_trigger, 'test label') }
+  let(:notifier) {
+    Notifier::Command.new(model) do |cmd|
+      cmd.command = 'notify-send'
+      cmd.args    = [
+        ->(model, status) { model.label.upcase },
+        "%V | %t"
+      ]
+    end
+  }
+
+  it_behaves_like 'a class that includes Config::Helpers'
+  it_behaves_like 'a subclass of Notifier::Base'
+
+  describe '#initialize' do
+    it 'provides default values' do
+      notifier = Notifier::Command.new(model)
+      expect( notifier.command ).to be_nil
+      expect( notifier.args    ).to eq( ["%L %v"] )
+    end
+
+    it 'configures the notifier' do
+      notifier = Notifier::Command.new(model) do |cmd|
+        cmd.command = 'my_command'
+        cmd.args    = 'my_args'
+      end
+
+      expect( notifier.command ).to eq 'my_command'
+      expect( notifier.args    ).to eq 'my_args'
+    end
+  end # describe '#initialize'
+
+
+  describe '#notify!' do
+    context 'when status is :success' do
+      it 'sends a success message' do
+        IO.expects(:popen).with(
+          [
+            "notify-send",
+            "TEST LABEL",
+            "Succeeded | test_trigger"
+          ]
+        )
+
+        notifier.send(:notify!, :success)
+      end
+    end
+
+    context 'when status is :warning' do
+      it 'sends a warning message' do
+        IO.expects(:popen).with(
+          [
+            "notify-send",
+            "TEST LABEL",
+            "Succeeded with warnings | test_trigger"
+          ]
+        )
+
+        notifier.send(:notify!, :warning)
+      end
+    end
+
+    context 'when status is :failure' do
+      it 'sends a failure message' do
+        IO.expects(:popen).with(
+          [
+            "notify-send",
+            "TEST LABEL",
+            "Failed | test_trigger"
+          ]
+        )
+
+        notifier.send(:notify!, :failure)
+      end
+    end
+  end # describe '#notify!'
+
+end
+end

--- a/templates/cli/notifiers/command
+++ b/templates/cli/notifiers/command
@@ -1,0 +1,32 @@
+  ##
+  # Command [Notifier]
+  #
+  notify_by Command do |cmd|
+    cmd.on_success = true
+    cmd.on_warning = true
+    cmd.on_failure = true
+
+    # Command to execute
+    cmd.command = 'notify-send'
+
+    # Arguments to pass to the command.
+    #
+    # Must be an array of strings or callable objects.
+    #
+    # Callables will be invoked with #call(model, status),
+    # and the return value used as the argument.
+    #
+    # In strings you can use the following placeholders:
+    #
+    # %l - Model label
+    # %t - Model trigger
+    # %s - Status (success/failure/warning)
+    # %v - Status verb (succeeded/failed/succeeded with warnings)
+    #
+    # All placeholders can be used with uppercase letters to capitalize
+    # the value.
+    #
+    # Defaults to ["%L %v"]
+    #
+    # cmd.args = ["Backup %L", "%V"]
+  end


### PR DESCRIPTION
I added a notifier that just invokes a command. Useful for example for Ubuntu's OSD notifications (notify-send).

Do you need documentation apart from the rdoc?