### PR TITLE
add ssh option to mysql module

### DIFF
--- a/lib/backup/database/mysql.rb
+++ b/lib/backup/database/mysql.rb
@@ -15,6 +15,10 @@ module Backup
       attr_accessor :username, :password
 
       ##
+      # SSH option
+      attr_accessor :ssh
+
+      ##
       # Connectivity options
       attr_accessor :host, :port, :socket
 
@@ -101,9 +105,13 @@ module Backup
       private
 
       def mysqldump
-        "#{ utility(:mysqldump) } #{ credential_options } " +
+        "#{ ssh_option } #{ utility(:mysqldump) } #{ credential_options } " +
         "#{ connectivity_options } #{ user_options } #{ name_option } " +
         "#{ tables_to_dump } #{ tables_to_skip }"
+      end
+
+      def ssh_option
+        "ssh #{ssh}" if ssh
       end
 
       def credential_options


### PR DESCRIPTION
I need to create a backup from a MySQL database running on another server, but the database is configured to not allow remote connections and the database user can also just log in from localhost. I don't want to change either of those things for security reasons.
The solution for me was to simply use SSH to connect to the server and stream the backup to the backup server.
So instead of this:
```
/usr/bin/mysqldump --user=my_user --password=my_password --host='db_server_ip' --port='my_port' my_db
```
I did this:
```
ssh db_server_user@db_server_ip /usr/bin/mysqldump --user=my_user --password=my_password --host='localhost' --port='my_port' my_db
```
To make this possible with this gem, all that's needed is a `ssh` option on the MySQL module, which this PR implements (tests are missing obviously, I just wanted to propose this change for now).
Would this be something you would accept?
We could also maybe implement it in a more generic way, so that other backup commands can also be executed via SSH on another server.