### PR TITLE
Attempt all configured Storages, regardless of errors

### DIFF
--- a/lib/backup/model.rb
+++ b/lib/backup/model.rb
@@ -337,10 +337,14 @@ module Backup
         end
       end
 
-      first_storage_exception = storage_results.detect { |result| result.is_a? Exception }
+      first_exception, *other_exceptions = storage_results.select { |result| result.is_a? Exception }
 
-      if first_storage_exception
-        raise first_storage_exception
+      if first_exception
+        other_exceptions.each do |exception|
+         Logger.error exception.to_s
+         Logger.error exception.backtrace.join('\n')
+        end
+        raise first_exception
       else
         true
       end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -641,7 +641,7 @@ describe 'Backup::Model' do
     before do
       model.stubs(:prepare!).returns(:prepare)
       model.stubs(:package!).returns(:package)
-      model.stubs(:storages).returns([:storage])
+      model.stubs(:store!).returns([:storage])
       model.stubs(:clean!).returns(:clean)
     end
 
@@ -662,7 +662,7 @@ describe 'Backup::Model' do
         two.should == [:database]
         three.should == []
         four.call.should == :package
-        five.should == [:storage]
+        five.call.should == [:storage]
         six.call.should == :clean
       end
     end
@@ -678,7 +678,7 @@ describe 'Backup::Model' do
         two.should == []
         three.should == [:archive]
         four.call.should == :package
-        five.should == [:storage]
+        five.call.should == [:storage]
         six.call.should == :clean
       end
     end
@@ -698,6 +698,41 @@ describe 'Backup::Model' do
       Backup::Cleaner.expects(:remove_packaging).in_sequence(s).with(model)
 
       model.send(:package!)
+    end
+  end
+
+  describe '#store!' do
+    context 'when no storages are configured' do
+      before do
+        model.stubs(:storages).returns([])
+      end
+
+      it 'should return true' do
+        expect(model.send(:store!)).to eq true
+      end
+    end
+
+    context 'when multiple storages are configured' do
+      let(:storage_one) { mock() }
+      let(:storage_two) { mock() }
+
+      before do
+        model.stubs(:storages).returns([storage_one, storage_two])
+      end
+
+      it 'should call storages in sequence and return true if all succeed' do
+        storage_one.expects(:perform!).in_sequence(s).returns(true)
+        storage_two.expects(:perform!).in_sequence(s).returns(true)
+
+        expect(model.send(:store!)).to eq true
+      end
+
+      it 'should call storages in sequence and re-raise the first exception that occours' do
+        storage_one.expects(:perform!).in_sequence(s).raises 'Storage error'
+        storage_two.expects(:perform!).in_sequence(s).returns(true)
+
+        expect { model.send(:store!) }.to raise_error 'Storage error'
+      end
     end
   end
 


### PR DESCRIPTION
So that when one storage does not work, data has a chance of being stored elsewhere.

I had a recent experience, where backups configured to be stored via SCP and S3 storages were failing due to connection issues to SCP destination. Connection to S3 was still usable, but no backups were being made via that because SCP was attempted first, and failing.