### PR TITLE
Allow hipchat version to be specified.

### DIFF
--- a/lib/backup/notifier/hipchat.rb
+++ b/lib/backup/notifier/hipchat.rb
@@ -10,6 +10,11 @@ module Backup
       attr_accessor :token
 
       ##
+      # The Hipchat API version
+      # Either 'v1' or 'v2' (default is 'v1')
+      attr_accessor :api_version
+
+      ##
       # Who the notification should appear from
       attr_accessor :from
 
@@ -45,6 +50,7 @@ module Backup
         @success_color  ||= 'yellow'
         @warning_color  ||= 'yellow'
         @failure_color  ||= 'yellow'
+        @api_version    ||= 'v1'
       end
 
       private
@@ -76,9 +82,13 @@ module Backup
         send_message(message, color)
       end
 
+      def client_options
+        { api_version: @api_version }
+      end
+
       # Hipchat::Client will raise an error if unsuccessful.
       def send_message(msg, color)
-        client = HipChat::Client.new(token)
+        client = HipChat::Client.new(token, client_options)
         rooms_to_notify.each do |room|
           client[room].send(from, msg, :color => color, :notify => notify_users)
         end

--- a/spec/notifier/hipchat_spec.rb
+++ b/spec/notifier/hipchat_spec.rb
@@ -14,6 +14,7 @@ describe Notifier::Hipchat do
   describe '#initialize' do
     it 'provides default values' do
       expect( notifier.token          ).to be_nil
+      expect( notifier.api_version    ).to eq 'v1'
       expect( notifier.from           ).to be_nil
       expect( notifier.rooms_notified ).to eq []
       expect( notifier.notify_users   ).to be(false)
@@ -73,6 +74,7 @@ describe Notifier::Hipchat do
         hipchat.failure_color   = :failure_color
       end
     }
+    let(:client_options) { {api_version: 'v1'} }
     let(:client) { mock }
     let(:room) { mock }
     let(:message) { '[Backup::%s] test label (test_trigger)' }
@@ -80,7 +82,7 @@ describe Notifier::Hipchat do
     context 'when status is :success' do
       it 'sends a success message' do
         HipChat::Client.expects(:new).in_sequence(s).
-            with('my_token').returns(client)
+            with('my_token', client_options).returns(client)
         client.expects(:[]).in_sequence(s).
             with('room_a').returns(room)
         room.expects(:send).in_sequence(s).
@@ -99,7 +101,7 @@ describe Notifier::Hipchat do
     context 'when status is :warning' do
       it 'sends a warning message' do
         HipChat::Client.expects(:new).in_sequence(s).
-            with('my_token').returns(client)
+            with('my_token', client_options).returns(client)
         client.expects(:[]).in_sequence(s).
             with('room_a').returns(room)
         room.expects(:send).in_sequence(s).
@@ -118,7 +120,7 @@ describe Notifier::Hipchat do
     context 'when status is :failure' do
       it 'sends a failure message' do
         HipChat::Client.expects(:new).in_sequence(s).
-            with('my_token').returns(client)
+            with('my_token', client_options).returns(client)
         client.expects(:[]).in_sequence(s).
             with('room_a').returns(room)
         room.expects(:send).in_sequence(s).


### PR DESCRIPTION
This change allows the hipchat version to be specified, so the hipchat v2 api can be used.