### PR TITLE
Allow custom messages in certain notifiers

### DIFF
--- a/lib/backup/notifier/campfire.rb
+++ b/lib/backup/notifier/campfire.rb
@@ -42,13 +42,7 @@ module Backup
       # : Notification will be sent if `on_warning` or `on_success` is `true`.
       #
       def notify!(status)
-        tag = case status
-              when :success then '[Backup::Success]'
-              when :warning then '[Backup::Warning]'
-              when :failure then '[Backup::Failure]'
-              end
-        message = "#{ tag } #{ model.label } (#{ model.trigger })"
-        send_message(message)
+        send_message(message.call(model, :status => status_data_for(status)))
       end
 
       def send_message(message)

--- a/lib/backup/notifier/flowdock.rb
+++ b/lib/backup/notifier/flowdock.rb
@@ -61,15 +61,16 @@ module Backup
       # : Notification will be sent if `on_warning` or `on_success` is `true`.
       #
       def notify!(status)
-        @tags  += default_tags(status)
-        message = "#{ model.label } (#{ model.trigger })"
-        send_message(message)
+        @tags += default_tags(status)
+        send_message(message.call(model, status: status_data_for(status)))
       end
 
       # Flowdock::Client will raise an error if unsuccessful.
       def send_message(msg)
-        client = Flowdock::Flow.new(:api_token => token, :source => source,
-                                    :from => {:name => from_name, :address => from_email })
+        client = Flowdock::Flow.new(
+          :api_token => token, :source => source,
+          :from => {:name => from_name, :address => from_email }
+        )
 
         client.push_to_team_inbox(:subject => subject,
                                   :content => msg,

--- a/lib/backup/notifier/hipchat.rb
+++ b/lib/backup/notifier/hipchat.rb
@@ -67,13 +67,9 @@ module Backup
       # : Notification will be sent if `on_warning` or `on_success` is `true`.
       #
       def notify!(status)
-        tag, color = case status
-                     when :success then ['[Backup::Success]', success_color]
-                     when :warning then ['[Backup::Warning]', warning_color]
-                     when :failure then ['[Backup::Failure]', failure_color]
-                     end
-        message = "#{ tag } #{ model.label } (#{ model.trigger })"
-        send_message(message, color)
+        status_data = status_data_for(status)
+        msg = message.call(model, :status => status_data)
+        send_message(msg, status_data[:color])
       end
 
       # Hipchat::Client will raise an error if unsuccessful.
@@ -88,6 +84,19 @@ module Backup
         Array(rooms_notified).map {|r| r.split(',').map(&:strip) }.flatten
       end
 
+      def status_data_for(status)
+        data = super(status)
+        data[:color] = status_color_for(status)
+        data
+      end
+
+      def status_color_for(status)
+        {
+          :success => success_color,
+          :warning => warning_color,
+          :failure => failure_color
+        }[status]
+      end
     end
   end
 end

--- a/lib/backup/notifier/http_post.rb
+++ b/lib/backup/notifier/http_post.rb
@@ -95,18 +95,13 @@ module Backup
       # : Notification will be sent if `on_warning` or `on_success` is `true`.
       #
       def notify!(status)
-        tag = case status
-              when :success then '[Backup::Success]'
-              when :failure then '[Backup::Failure]'
-              when :warning then '[Backup::Warning]'
-              end
-        message = "#{ tag } #{ model.label } (#{ model.trigger })"
+        msg = message.call(model, :status => status_data_for(status))
 
         opts = {
           :headers => { 'User-Agent' => "Backup/#{ VERSION }" }.
               merge(headers).reject {|k,v| v.nil? }.
               merge('Content-Type' => 'application/x-www-form-urlencoded'),
-          :body => URI.encode_www_form({ 'message' => message }.
+          :body => URI.encode_www_form({ 'message' => msg }.
               merge(params).reject {|k,v| v.nil? }.
               merge('status' => status.to_s)),
           :expects => success_codes # raise error if unsuccessful

--- a/lib/backup/notifier/mail.rb
+++ b/lib/backup/notifier/mail.rb
@@ -148,14 +148,8 @@ module Backup
       # : backup log, if `on_failure` is `true`.
       #
       def notify!(status)
-        tag = case status
-              when :success then '[Backup::Success]'
-              when :warning then '[Backup::Warning]'
-              when :failure then '[Backup::Failure]'
-              end
-
         email = new_email
-        email.subject = "#{ tag } #{ model.label } (#{ model.trigger })"
+        email.subject = message.call(model, :status => status_data_for(status))
 
         send_log = send_log_on.include?(status)
         template = Backup::Template.new({ :model => model, :send_log => send_log })

--- a/lib/backup/notifier/nagios.rb
+++ b/lib/backup/notifier/nagios.rb
@@ -55,12 +55,7 @@ module Backup
       # : Notification will be sent if `on_warning` or `on_success` is `true`.
       #
       def notify!(status)
-        message = case status
-              when :success then 'Completed Successfully'
-              when :warning then 'Completed Successfully (with Warnings)'
-              when :failure then 'Failed'
-              end
-        send_message("#{model.label}: #{ message } in #{ model.duration }")
+        send_message(message.call(model, :status => status_data_for(status)))
       end
 
       def send_message(message)

--- a/lib/backup/notifier/pushover.rb
+++ b/lib/backup/notifier/pushover.rb
@@ -51,13 +51,7 @@ module Backup
       # : Notification will be sent if `on_warning` or `on_success` is `true`.
       #
       def notify!(status)
-        tag = case status
-              when :success then '[Backup::Success]'
-              when :failure then '[Backup::Failure]'
-              when :warning then '[Backup::Warning]'
-              end
-        message = "#{ tag } #{ model.label } (#{ model.trigger })"
-        send_message(message)
+        send_message(message.call(model, :status => status_data_for(status)))
       end
 
       def send_message(message)

--- a/lib/backup/notifier/ses.rb
+++ b/lib/backup/notifier/ses.rb
@@ -66,14 +66,8 @@ module Backup
       # : backup log, if `on_failure` is `true`.
       #
       def notify!(status)
-        tag = case status
-                when :success then '[Backup::Success]'
-                when :warning then '[Backup::Warning]'
-                when :failure then '[Backup::Failure]'
-              end
-
         email = ::Mail.new(:to => to, :from => from)
-        email.subject = "#{ tag } #{ model.label } (#{ model.trigger })"
+        email.subject = message.call(model, :status => status_data_for(status))
 
         send_log = send_log_on.include?(status)
         template = Backup::Template.new({ :model => model, :send_log => send_log })

--- a/lib/backup/notifier/slack.rb
+++ b/lib/backup/notifier/slack.rb
@@ -61,20 +61,14 @@ module Backup
       # : Notification will be sent if `on_warning` or `on_success` is `true`.
       #
       def notify!(status)
-        tag = case status
-              when :success then '[Backup::Success]'
-              when :failure then '[Backup::Failure]'
-              when :warning then '[Backup::Warning]'
-              end
-        message = "#{ tag } #{ model.label } (#{ model.trigger })"
-
-        data = { :text => message }
+        data = {
+          :text => message.call(model, :status => status_data_for(status)),
+          :attachments => [attachment(status)]
+        }
         [:channel, :username, :icon_emoji].each do |param|
           val = send(param)
           data.merge!(param => val) if val
         end
-
-        data.merge!(:attachments => [attachment(status)])
 
         options = {
           :headers  => { 'Content-Type' => 'application/x-www-form-urlencoded' },

--- a/lib/backup/notifier/twitter.rb
+++ b/lib/backup/notifier/twitter.rb
@@ -38,13 +38,7 @@ module Backup
       # : Notification will be sent if `on_warning` or `on_success` is `true`.
       #
       def notify!(status)
-        tag = case status
-              when :success then '[Backup::Success]'
-              when :warning then '[Backup::Warning]'
-              when :failure then '[Backup::Failure]'
-              end
-        message = "#{ tag } #{ model.label } (#{ model.trigger }) (@ #{ model.time })"
-        send_message(message)
+        send_message(message.call(model, :status => status_data_for(status)))
       end
 
       # Twitter::Client will raise an error if unsuccessful.

--- a/lib/backup/notifier/zabbix.rb
+++ b/lib/backup/notifier/zabbix.rb
@@ -45,12 +45,7 @@ module Backup
       # : Notification will be sent if `on_warning` or `on_success` is `true`.
       #
       def notify!(status)
-        message = case status
-              when :success then 'Completed Successfully'
-              when :warning then 'Completed Successfully (with Warnings)'
-              when :failure then 'Failed'
-              end
-        send_message("#{ message } in #{ model.duration }")
+        send_message(message.call(model, :status => status_data_for(status)))
       end
 
       def send_message(message)

--- a/spec/notifier/datadog_spec.rb
+++ b/spec/notifier/datadog_spec.rb
@@ -15,7 +15,6 @@ module Backup
       it 'provides default values' do
         expect( notifier.api_key          ).to be_nil
         expect( notifier.title            ).to eq 'Backup test label'
-        expect( notifier.text             ).to eq 'Backup Notification for test label'
         expect( notifier.date_happened    ).to be_nil
         expect( notifier.priority         ).to be_nil
         expect( notifier.host             ).to be_nil
@@ -34,7 +33,6 @@ module Backup
         notifier = Notifier::DataDog.new(model) do |datadog|
           datadog.api_key          = 'my_key'
           datadog.title            = 'Backup!'
-          datadog.text             = 'More Backup!'
           datadog.date_happened    = 12345
           datadog.priority         = 'low'
           datadog.host             = 'local'
@@ -51,7 +49,6 @@ module Backup
 
         expect( notifier.api_key          ).to eq 'my_key'
         expect( notifier.title            ).to eq 'Backup!'
-        expect( notifier.text             ).to eq 'More Backup!'
         expect( notifier.date_happened    ).to eq 12345
         expect( notifier.priority         ).to eq 'low'
         expect( notifier.host             ).to eq 'local'
@@ -82,7 +79,10 @@ module Backup
           Dogapi::Client.expects(:new).in_sequence(s).
             with('my_token').returns(client)
           Dogapi::Event.expects(:new).in_sequence(s).
-            with('Backup Notification for test label', {:msg_title => 'Backup test label', :alert_type => 'success'}).returns(event)
+            with(
+              '[Backup::Success] test label (test_trigger)',
+              {:msg_title => 'Backup test label', :alert_type => 'success'}
+            ).returns(event)
           client.expects(:emit_event).in_sequence(s).
             with(event)
 
@@ -95,7 +95,10 @@ module Backup
           Dogapi::Client.expects(:new).in_sequence(s).
             with('my_token').returns(client)
           Dogapi::Event.expects(:new).in_sequence(s).
-            with('Backup Notification for test label', {:msg_title => 'Backup test label', :alert_type => 'warning'}).returns(event)
+            with(
+              '[Backup::Warning] test label (test_trigger)',
+              {:msg_title => 'Backup test label', :alert_type => 'warning'}
+            ).returns(event)
           client.expects(:emit_event).in_sequence(s).
             with(event)
 
@@ -108,7 +111,10 @@ module Backup
           Dogapi::Client.expects(:new).in_sequence(s).
             with('my_token').returns(client)
           Dogapi::Event.expects(:new).in_sequence(s).
-            with('Backup Notification for test label', {:msg_title => 'Backup test label', :alert_type => 'error'}).returns(event)
+            with(
+              '[Backup::Failure] test label (test_trigger)',
+               {:msg_title => 'Backup test label', :alert_type => 'error'}
+            ).returns(event)
           client.expects(:emit_event).in_sequence(s).
             with(event)
 

--- a/spec/notifier/flowdock_spec.rb
+++ b/spec/notifier/flowdock_spec.rb
@@ -66,7 +66,7 @@ module Backup
       }
       let(:client) { mock }
       let(:push_to_team_inbox) { mock }
-      let(:message) { 'test label (test_trigger)' }
+      let(:message) { '[Backup::%s] test label (test_trigger)' }
 
       context 'when status is :success' do
         it 'sends a success message' do
@@ -76,7 +76,7 @@ module Backup
                     ).returns(client)
           client.expects(:push_to_team_inbox).in_sequence(s).
               with(:subject => 'My Daily Backup',
-                   :content => message,
+                   :content => message % 'Success',
                    :tags => [ 'prod', '#BackupSuccess' ],
                    :link => 'www.example.com' )
 
@@ -92,7 +92,7 @@ module Backup
                     ).returns(client)
           client.expects(:push_to_team_inbox).in_sequence(s).
               with(:subject => 'My Daily Backup',
-                   :content => message,
+                   :content => message % 'Warning',
                    :tags => [ 'prod', '#BackupWarning' ],
                    :link => 'www.example.com' )
 
@@ -108,7 +108,7 @@ module Backup
                     ).returns(client)
           client.expects(:push_to_team_inbox).in_sequence(s).
               with(:subject => 'My Daily Backup',
-                   :content => message,
+                   :content => message % 'Failure',
                    :tags => [ 'prod', '#BackupFailure' ],
                    :link => 'www.example.com' )
 

--- a/spec/notifier/nagios_spec.rb
+++ b/spec/notifier/nagios_spec.rb
@@ -69,8 +69,8 @@ describe Notifier::Nagios do
 
     context 'when status is :success' do
       let(:nagios_msg) {
-        "my.service.host\tBackup test_trigger\t0\t" +
-        "test model: Completed Successfully in 12:34:56"
+        "my.service.host\tBackup test_trigger\t0\t"\
+        "[Backup::Success] test model (test_trigger)"
       }
       before { model.stubs(:exit_status).returns(0) }
 
@@ -83,8 +83,8 @@ describe Notifier::Nagios do
 
     context 'when status is :warning' do
       let(:nagios_msg) {
-        "my.service.host\tBackup test_trigger\t1\t" +
-        "test model: Completed Successfully (with Warnings) in 12:34:56"
+        "my.service.host\tBackup test_trigger\t1\t"\
+        "[Backup::Warning] test model (test_trigger)"
       }
       before { model.stubs(:exit_status).returns(1) }
 
@@ -97,7 +97,8 @@ describe Notifier::Nagios do
 
     context 'when status is :failure' do
       let(:nagios_msg) {
-        "my.service.host\tBackup test_trigger\t2\ttest model: Failed in 12:34:56"
+        "my.service.host\tBackup test_trigger\t2\t"\
+        "[Backup::Failure] test model (test_trigger)"
       }
       before { model.stubs(:exit_status).returns(2) }
 

--- a/spec/notifier/prowl_spec.rb
+++ b/spec/notifier/prowl_spec.rb
@@ -53,8 +53,8 @@ describe Notifier::Prowl do
       end
     }
     let(:form_data) {
-      'application=my_app&apikey=my_api_key&' +
-      'event=%5BBackup%3A%3A' + 'STATUS' + '%5D&' +
+      'application=my_app&apikey=my_api_key&'\
+      'event=Backup%3A%3ASTATUS&'\
       'description=test+label+%28test_trigger%29'
     }
 

--- a/spec/notifier/twitter_spec.rb
+++ b/spec/notifier/twitter_spec.rb
@@ -52,11 +52,7 @@ describe Notifier::Twitter do
   end # describe '#initialize'
 
   describe '#notify!' do
-    let(:message) { '[Backup::%s] test label (test_trigger) (@ model-time)' }
-
-    before do
-      model.stubs(:time).returns('model-time')
-    end
+    let(:message) { '[Backup::%s] test label (test_trigger)' }
 
     context 'when status is :success' do
       it 'sends a success message' do

--- a/spec/notifier/zabbix_spec.rb
+++ b/spec/notifier/zabbix_spec.rb
@@ -68,11 +68,11 @@ module Backup
 
       context 'when status is :success' do
         let(:zabbix_msg) {
-          "my.service.host\tBackup test_trigger\t0\t" +
-          "Completed Successfully in #{ model.duration }"
+          "my.service.host\tBackup test_trigger\t0\t"\
+          "[Backup::Success] test label (test_trigger)"
         }
 
-        let(:zabbix_cmd) { 
+        let(:zabbix_cmd) {
           "zabbix_sender -z 'zabbix.hostname'" +
           " -p '#{ notifier.zabbix_port }'" +
           " -s #{ notifier.service_host }" +
@@ -90,11 +90,11 @@ module Backup
 
       context 'when status is :warning' do
         let(:zabbix_msg) {
-          "my.service.host\tBackup test_trigger\t1\t" +
-          "Completed Successfully (with Warnings) in #{ model.duration }"
+          "my.service.host\tBackup test_trigger\t1\t"\
+          "[Backup::Warning] test label (test_trigger)"
         }
 
-        let(:zabbix_cmd) { 
+        let(:zabbix_cmd) {
           "zabbix_sender -z 'zabbix.hostname'" +
           " -p '#{ notifier.zabbix_port }'" +
           " -s #{ notifier.service_host }" +
@@ -112,10 +112,11 @@ module Backup
 
       context 'when status is :failure' do
         let(:zabbix_msg) {
-          "my.service.host\tBackup test_trigger\t2\tFailed in #{ model.duration }"
+          "my.service.host\tBackup test_trigger\t2\t"\
+          "[Backup::Failure] test label (test_trigger)"
         }
 
-        let(:zabbix_cmd) { 
+        let(:zabbix_cmd) {
           "zabbix_sender -z 'zabbix.hostname'" +
           " -p '#{ notifier.zabbix_port }'" +
           " -s #{ notifier.service_host }" +


### PR DESCRIPTION
This change makes it possible to customize messages send through notifiers. Closes #697

## Notifiers changed

The following notifiers have been updated to use the `message` lambda to compose message. Their messages also use the standard format of:
```
[Backup::Success] test model (test_trigger)
[Backup::Warning] test model (test_trigger)
[Backup::Failure] test model (test_trigger)
```

- Campfire
- Datadog (with `text` attribute deprecation)
- Flowdock
- HipChat
- Http post
- Mail
- Nagios
- Prowl (uses message: `test model (test trigger)`, because the event title is the `Backup::Success` label)
- Pushover
- SES
- Slack
- Twitter
- Zabbix

## Notifiers **un**changed

The following notifiers have not been changed to use this method, because they differ too much to use this.

- Command
- Pagerduty

## Usage

To change the notifier message on the notifier override the `message` attribute on the notifier in your model.

```ruby
notify_by Campfire do |campfire|
  campfire.message = lambda do |model, data|
    "[#{data[:status][:message]}] #{model.label} (#{model.trigger})"
  end
end
```

The model is the current model that is being executed. There are several more methods to use to create more useful messages, such as `duration`. For all `Model` attributes and method see the [documentation](http://www.rubydoc.info/gems/backup/4.1.12/Backup/Model).
In most cases `data` is this hash:

```ruby
{
  :status => {
    :message => "Backup::Success",
    :key => :success
  }
}
```

HipChat is slightly different as it has a color, which is still something you can customize on the notifier itself.

```ruby
{
  :status => {
    :message => "Backup::Success",
    :key => :success,
    :color => "green"
  }
}
```