### PR TITLE
link to the release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+see http://backup.github.io/backup/v4/release-notes/


### PR DESCRIPTION
I think most (ruby) devs will be looking to a `CHANGELOG` or `HISTORY` file when they want to find out about releases.  This should make sure that they will find what they are looking for.

fixes issue #309