### PR TITLE
Fix to negative array size error in cycler

### DIFF
--- a/lib/backup/storage/cycler.rb
+++ b/lib/backup/storage/cycler.rb
@@ -22,7 +22,7 @@ module Backup
           end
         else
           excess = packages.count - keep.to_i
-          cycled_packages = packages.last(excess)
+          cycled_packages = packages.last(excess) if excess > 0
         end
 
         saved_packages = packages - cycled_packages

--- a/spec/support/shared_examples/storage.rb
+++ b/spec/support/shared_examples/storage.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require 'awesome_print'
 
 shared_examples 'a subclass of Storage::Base' do
   let(:storage_name) { described_class.name.sub('Backup::', '') }
@@ -114,16 +113,11 @@ shared_examples 'a storage that cycles' do
 
       storage.keep = 2
 
-      puts storage.keep
-
       FileUtils.expects(:mkdir_p).with(File.dirname(yaml_file))
       file = mock
       File.expects(:open).with(yaml_file, 'w').yields(file)
       saved_packages = [storage.package, pkg_a]
       file.expects(:write).with(saved_packages.to_yaml)
-
-      ap saved_packages
-      ap storage.package
 
       storage.perform!
     end

--- a/spec/support/shared_examples/storage.rb
+++ b/spec/support/shared_examples/storage.rb
@@ -131,8 +131,6 @@ shared_examples 'a storage that cycles' do
 
       storage.keep = 5
 
-      puts storage.keep
-
       FileUtils.expects(:mkdir_p).with(File.dirname(yaml_file))
       file = mock
       File.expects(:open).with(yaml_file, 'w').yields(file)

--- a/spec/support/shared_examples/storage.rb
+++ b/spec/support/shared_examples/storage.rb
@@ -87,7 +87,7 @@ shared_examples 'a storage that cycles' do
       File.expects(:open).with(yaml_file, 'w').yields(file)
       saved_packages = [storage.package, pkg_a]
       file.expects(:write).with(saved_packages.to_yaml)
-
+      #storage.expects(:cycle!)
       storage.perform!
     end
 
@@ -100,6 +100,26 @@ shared_examples 'a storage that cycles' do
       file = mock
       File.expects(:open).with(yaml_file, 'w').yields(file)
       saved_packages = [storage.package, pkg_a]
+      file.expects(:write).with(saved_packages.to_yaml)
+
+      storage.perform!
+    end
+
+
+    it 'does not cycle when the available packages are less than the keep setting' do
+
+      storage.expects(:remove!).with(pkg_a).never
+      storage.expects(:remove!).with(pkg_b).never
+      storage.expects(:remove!).with(pkg_c).never
+
+      storage.keep = 5
+
+      puts storage.keep
+
+      FileUtils.expects(:mkdir_p).with(File.dirname(yaml_file))
+      file = mock
+      File.expects(:open).with(yaml_file, 'w').yields(file)
+      saved_packages = [storage.package, pkg_a, pkg_b, pkg_c]
       file.expects(:write).with(saved_packages.to_yaml)
 
       storage.perform!

--- a/spec/support/shared_examples/storage.rb
+++ b/spec/support/shared_examples/storage.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'awesome_print'
 
 shared_examples 'a subclass of Storage::Base' do
   let(:storage_name) { described_class.name.sub('Backup::', '') }
@@ -87,7 +88,7 @@ shared_examples 'a storage that cycles' do
       File.expects(:open).with(yaml_file, 'w').yields(file)
       saved_packages = [storage.package, pkg_a]
       file.expects(:write).with(saved_packages.to_yaml)
-      #storage.expects(:cycle!)
+
       storage.perform!
     end
 
@@ -101,6 +102,28 @@ shared_examples 'a storage that cycles' do
       File.expects(:open).with(yaml_file, 'w').yields(file)
       saved_packages = [storage.package, pkg_a]
       file.expects(:write).with(saved_packages.to_yaml)
+
+      storage.perform!
+    end
+
+    it 'does cycle when the available packages are more than the keep setting' do
+
+      storage.expects(:remove!).with(pkg_a).never
+      storage.expects(:remove!).with(pkg_b)
+      storage.expects(:remove!).with(pkg_c)
+
+      storage.keep = 2
+
+      puts storage.keep
+
+      FileUtils.expects(:mkdir_p).with(File.dirname(yaml_file))
+      file = mock
+      File.expects(:open).with(yaml_file, 'w').yields(file)
+      saved_packages = [storage.package, pkg_a]
+      file.expects(:write).with(saved_packages.to_yaml)
+
+      ap saved_packages
+      ap storage.package
 
       storage.perform!
     end


### PR DESCRIPTION
Currently the cycler fails if the keep value is set. 

I've written a couple of tests which fail with the version 4.2.1 and the simple fix which should fix it.