### PR TITLE
Require time library

### DIFF
--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 # Load Ruby Core Libraries
+require 'time'
 require 'fileutils'
 require 'tempfile'
 require 'syslog'

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -82,5 +82,13 @@ describe Package do
     end
   end
 
+  describe '#time_as_object' do
+    it 'returns Time object from string' do
+      package.time = dummy_time = '2015.12.30.20.45.59'
+      expect( package.time_as_object )
+        .to eq Time.strptime(dummy_time, '%Y.%m.%d.%H.%M.%S')
+    end
+  end
+
 end
 end


### PR DESCRIPTION
In normal envs the Time library isn't loaded unless explicitly called.
It works in the test environment, because the timecop gem is loaded and
this requires the time library for us.

Now explictly requiring time and adding a spec for the method that
depends on it (since I forgot to write it when adding it).

Closes #727