### PR TITLE
Fix [warn] could not change directory to "/root"

### DIFF
--- a/lib/backup/database/postgresql.rb
+++ b/lib/backup/database/postgresql.rb
@@ -92,7 +92,7 @@ module Backup
       end
 
       def sudo_option
-        "#{ utility(:sudo) } -n -u #{ sudo_user } " if sudo_user
+        "#{ utility(:sudo) } -n -H -u #{ sudo_user } " if sudo_user
       end
 
       def username_option

--- a/spec/database/postgresql_spec.rb
+++ b/spec/database/postgresql_spec.rb
@@ -235,7 +235,7 @@ describe Database::PostgreSQL do
         expect( db.send(:sudo_option) ).to be_nil
 
         db.sudo_user = 'my_sudo_user'
-        expect( db.send(:sudo_option) ).to eq 'sudo -n -u my_sudo_user '
+        expect( db.send(:sudo_option) ).to eq 'sudo -n -H -u my_sudo_user '
       end
     end # describe '#sudo_option'
 


### PR DESCRIPTION
As mentioned already in #695 , this is a common issue with postgresql backups + use_sudo.

A better fix than ignoring the logs would be to use sudo -H