### PR TITLE
use dropbox-sdk in newest 1.6.5 version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :production do
   gem 'fog'
   # gem 'excon' - use version specified by fog
   gem 'unf' # for fog/AWS
-  gem 'dropbox-sdk', '= 1.5.1' # patched
+  gem 'dropbox-sdk', '1.6.5'
   gem 'net-ssh'
   gem 'net-scp'
   gem 'net-sftp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     diff-lcs (1.2.5)
     dogapi (1.11.0)
       json (>= 1.5.1)
-    dropbox-sdk (1.5.1)
+    dropbox-sdk (1.6.5)
       json
     equalizer (0.0.9)
     excon (0.44.4)
@@ -197,7 +197,7 @@ PLATFORMS
 DEPENDENCIES
   aws-ses
   dogapi
-  dropbox-sdk (= 1.5.1)
+  dropbox-sdk (= 1.6.5)
   flowdock
   fog
   fuubar
@@ -222,4 +222,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/backup.gemspec
+++ b/backup.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'builder', '= 3.2.2'
   gem.add_dependency 'descendants_tracker', '= 0.0.3'
   gem.add_dependency 'dogapi', '= 1.11.0'
-  gem.add_dependency 'dropbox-sdk', '= 1.5.1'
+  gem.add_dependency 'dropbox-sdk', '= 1.6.5'
   gem.add_dependency 'equalizer', '= 0.0.9'
   gem.add_dependency 'excon', '= 0.44.4'
   gem.add_dependency 'faraday', '= 0.8.8'

--- a/lib/backup/storage/dropbox.rb
+++ b/lib/backup/storage/dropbox.rb
@@ -220,7 +220,7 @@ class DropboxClient
         data = @file_obj.read(chunk_size)
 
         begin
-          resp = @client.parse_response(
+          resp = ::Dropbox::parse_response(
             @client.partial_chunked_upload(data, @upload_id, @offset)
           )
         rescue DropboxError => err


### PR DESCRIPTION
caused by #762.
Closes #762 

tests pass, needs some more testing in the wild.