### PR TITLE
Mail notifier support smtp with Amazon SES (with IAM user)

### DIFF
--- a/lib/backup/notifier/mail.rb
+++ b/lib/backup/notifier/mail.rb
@@ -191,7 +191,6 @@ module Backup
               opts = {
                 :address              => @address,
                 :port                 => @port,
-                :domain               => @domain,
                 :user_name            => @user_name,
                 :password             => @password,
                 :authentication       => @authentication,
@@ -203,7 +202,7 @@ module Backup
 
               # Don't override default domain setting if domain not applicable.
               # ref https://github.com/mikel/mail/blob/2.6.3/lib/mail/network/delivery_methods/smtp.rb#L82
-              opts.delete :domain if @domain.nil?
+              opts[:domain] = @domain if @domain
               opts
             when 'sendmail'
               opts = {}

--- a/lib/backup/notifier/mail.rb
+++ b/lib/backup/notifier/mail.rb
@@ -188,7 +188,8 @@ module Backup
         options =
             case method
             when 'smtp'
-              { :address              => @address,
+              opts = {
+                :address              => @address,
                 :port                 => @port,
                 :domain               => @domain,
                 :user_name            => @user_name,
@@ -199,6 +200,11 @@ module Backup
                 :ssl                  => @encryption == :ssl,
                 :tls                  => @encryption == :tls
               }
+
+              # Don't override default domain setting if domain not applicable.
+              # ref https://github.com/mikel/mail/blob/2.6.3/lib/mail/network/delivery_methods/smtp.rb#L82
+              opts.delete :domain if @domain.nil?
+              opts
             when 'sendmail'
               opts = {}
               opts.merge!(:location  => utility(:sendmail))

--- a/spec/notifier/mail_spec.rb
+++ b/spec/notifier/mail_spec.rb
@@ -396,6 +396,22 @@ describe Notifier::Mail do
         expect( settings[:ssl]                  ).to be(false)
         expect( settings[:tls]                  ).to be(true)
       end
+
+      it 'should not override mail smtp domain setting' do
+        Mail.defaults do
+          delivery_method :smtp, {
+                                   :domain => 'localhost.localdomain'
+                                 }
+        end
+
+        notifier.domain = nil
+
+        email = notifier.send(:new_email)
+
+        settings = email.delivery_method.settings
+
+        expect( settings[:domain] ).to eq 'localhost.localdomain'
+      end
     end
 
     context 'when delivery_method is :sendmail' do

--- a/spec/notifier/mail_spec.rb
+++ b/spec/notifier/mail_spec.rb
@@ -399,17 +399,12 @@ describe Notifier::Mail do
 
       it 'should not override mail smtp domain setting' do
         Mail.defaults do
-          delivery_method :smtp, {
-                                   :domain => 'localhost.localdomain'
-                                 }
+          delivery_method :smtp, :domain => 'localhost.localdomain'
         end
-
         notifier.domain = nil
-
         email = notifier.send(:new_email)
 
         settings = email.delivery_method.settings
-
         expect( settings[:domain] ).to eq 'localhost.localdomain'
       end
     end


### PR DESCRIPTION
Hi

I want to use SES (with IAM user) to send mail notifier.

One solution is [Notifier::Ses](http://backup.github.io/backup/v4/notifier-ses/), in this [issue](https://github.com/drewblas/aws-ses/issues/31), I found aws-ses gem should use [AWS Access Keys](https://console.aws.amazon.com/iam/home#security_credential), but AWS Access Keys was not recommend.

Another solution is [Notifier::Mail](http://backup.github.io/backup/v4/notifier-mail/), I try to run it with following scripts, the ```lib/ruby/2.2.0/net/smtp.rb:964:in `check_response': 501 Syntax: HELO <hostname> (Net::SMTPSyntaxError)``` error happened

```ruby
require "backup"

model = Backup::Model.new :trigger, 'label'
notifier = Backup::Notifier::Mail.new model

notifier.delivery_method = :smtp
notifier.address = 'email-smtp.us-east-1.amazonaws.com'
notifier.port = 587
notifier.user_name = ENV['SES_ACCESS_KEY_ID']
notifier.password = ENV['SES_ACCESS_KEY_SECRET']
notifier.authentication = 'plain'
notifier.encryption = :starttls

notifier.from = ENV['SES_FROM']
notifier.to = 'test@example.com'

notifier.send :notify!, :success
```

Then, I research and found that we should not override mail gem default domain setting, so, I fix it, please review it. thanks.




