### PR TITLE
Remove Mail.defaults

### DIFF
--- a/lib/backup/notifier/mail.rb
+++ b/lib/backup/notifier/mail.rb
@@ -215,11 +215,10 @@ module Backup
             when 'test' then {}
             end
 
-        ::Mail.defaults do
-          delivery_method method.to_sym, options
-        end
-
         email = ::Mail.new
+
+        email.delivery_method method.to_sym, options
+
         email.to       = to
         email.from     = from
         email.cc       = cc


### PR DESCRIPTION
Hi

Like [actionmailer](https://github.com/rails/rails/blob/v4.2.6/actionmailer/lib/action_mailer/delivery_methods.rb#L67), maybe ```mail.delivery_method :smtp, options``` is better than ```Mail.defaults{ delivery_method :smtp, options }```

So, please review it. thanks.