### PR TITLE
upgrade net-ssh

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.2)
+    net-ssh (3.2.0)
     netrc (0.11.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)

--- a/backup.gemspec
+++ b/backup.gemspec
@@ -75,7 +75,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'multipart-post', '= 1.2.0'
   gem.add_dependency 'net-scp', '= 1.2.1'
   gem.add_dependency 'net-sftp', '= 2.1.2'
-  gem.add_dependency 'net-ssh', '= 2.9.2'
+  gem.add_dependency 'net-ssh', '= 3.2.0'
   gem.add_dependency 'netrc', '= 0.11.0'
   gem.add_dependency 'nokogiri', '= 1.6.6.2'
   gem.add_dependency 'open4', '= 1.3.0'


### PR DESCRIPTION
### Background

We encountered several deprecation warnings when running the backups

```
/usr/local/rvm/gems/ruby-2.3.1@global/gems/net-ssh-2.9.2/lib/net/ssh/transport/session.rb:67:in `initialize': Object#timeout is deprecated, use Timeout.timeout instead.
/usr/local/rvm/gems/ruby-2.3.1@global/gems/net-ssh-2.9.2/lib/net/ssh/transport/session.rb:84:in `initialize': Object#timeout is deprecated, use Timeout.timeout instead.
/usr/local/rvm/gems/ruby-2.3.1@global/gems/net-ssh-2.9.2/lib/net/ssh/transport/session.rb:67:in `initialize': Object#timeout is deprecated, use Timeout.timeout instead.
/usr/local/rvm/gems/ruby-2.3.1@global/gems/net-ssh-2.9.2/lib/net/ssh/transport/session.rb:84:in `initialize': Object#timeout is deprecated, use Timeout.timeout instead.
```

### Changes

I upgraded net-ssh and regenerated the gemspec. The specs are green locally.

### Discussion 

Bundler chose net-ssh 3.2, which seems okay to me. The major-version change is essentially dropping support for Ruby 1.9. Since backup 4.x does not support 1.9, it seems like a nice match.

As intended side-effect, the deprecation warnings mentioned above should be gone.