### PR TITLE
Add duration to the command line notifier

### DIFF
--- a/lib/backup/notifier/command.rb
+++ b/lib/backup/notifier/command.rb
@@ -23,6 +23,7 @@ module Backup
       #
       # %l - Model label
       # %t - Model trigger
+      # %d - Backup duration (HH:MM:SS)
       # %s - Status (success/failure/warning)
       # %v - Status verb (succeeded/failed/succeeded with warnings)
       #

--- a/lib/backup/notifier/command.rb
+++ b/lib/backup/notifier/command.rb
@@ -73,6 +73,8 @@ module Backup
                     model.label
                   when "t"
                     model.trigger.to_s
+                  when "d"
+                    model.duration
                   when "v"
                     status_verb(status)
                   when "s"


### PR DESCRIPTION
I would like to use the backup duration in a custom command line notifier. This patch should provide it as an argument, %d.