### PR TITLE
Add CONTRIBUTING.md, GH #806

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ To report a bug, use the [GitHub issue tracker](https://github.com/backup/backup
 Backup is used with many different systems and configurations, so the first step for us to solve a problem is knowing how to reproduce it. You can help us solve your issue by including the versions of Ruby,
 Backup and the operating system on the computer that you used.
 
-To submit a bug fix, please create a [create a Pull Request](https://github.com/backup/backup/compare). Always develop changes against the
+To submit a bug fix, please [create a Pull Request](https://github.com/backup/backup/compare). Always develop changes against the
 `master` branch. Read the Pull Requests section below for more help with
 preparing fixes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,7 @@ Thank you for contributing to Backup!
 To report a bug, use the [GitHub issue tracker](https://github.com/backup/backup/issues). Please check the Open issues, and create a new issue if you do not see a report that matches the bug that you have found.
 
 Backup is used with many different systems and configurations, so the first step for us to solve a problem is knowing how to reproduce it. You can help us solve your issue by including the versions of Ruby,
-Backup and the operating system on both the computers that created the backups,
-and the computer that you use to restore backups.
+Backup and the operating system on the computer that you used.
 
 To submit a bug fix, please create a [create a Pull Request](https://github.com/backup/backup/compare). Always develop changes against the
 `master` branch. Read the Pull Requests section below for more help with
@@ -32,8 +31,7 @@ developing features in this project.
 
 If you would like to talk about either using Backup or writing code for it,
 please leave a message in our [Gitter room](https://gitter.im/backup/backup).
-Maintainers are not always online, but we will reply to any questions that you
-ask there.
+Maintainers are not online at all times, but we will reply to any questions that you ask there.
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Backup
+
+Thank you for contributing to Backup!
+
+## Bugs
+
+To report a bug, use the [GitHub issue tracker](https://github.com/backup/backup/issues). Please check the Open issues, and create a new issue if you do not see a report that matches the bug that you have found.
+
+Backup is used with many different systems and configurations, so the first step for us to solve a problem is knowing how to reproduce it. You can help us solve your issue by including the versions of Ruby,
+Backup and the operating system on both the computers that created the backups,
+and the computer that you use to restore backups.
+
+To submit a bug fix, please create a [create a Pull Request](https://github.com/backup/backup/compare). Always develop changes against the
+`master` branch. Read the Pull Requests section below for more help with
+preparing fixes.
+
+## New Features
+
+We are happy to discuss requests for specific features. Please check [the GitHub
+repository](https://github.com/backup/backup) to
+see if the feature has already been requested, and create a new Issue if there
+is not already an issue that describes the feature that you need. A good feature
+request will clearly explain the feature that is required, and include a use
+case.
+
+Of course, if you would like to write an implementation, that is even better! To
+submit a feature, please [create a Pull Request](https://github.com/backup/backup/compare). Always develop changes against the
+`master` branch. Read the Pull Requests section below for more help with
+developing features in this project.
+
+## Asking for (or Giving) Help
+
+If you would like to talk about either using Backup or writing code for it,
+please leave a message in our [Gitter room](https://gitter.im/backup/backup).
+Maintainers are not always online, but we will reply to any questions that you
+ask there.
+
+## Pull Requests
+
+We use the standard GitHub [Pull Requests feature](https://help.github.com/articles/about-pull-requests/). If you would like to discuss some details before you start working on a feature or bug fix, [open an issue](https://github.com/backup/backup/issues).
+
+To help us review your code:
+
+* Use the latest version of the `master` branch as the base for your topic branch
+* Be sure to use the latest version of Ruby 2 when you write and test your code
+* In the comment box for your pull request, specify the operating system(s) and Ruby version that you have tested your code on
+* Write [clear commit
+messages](http://chris.beams.io/posts/git-commit/):
+the first line should be 50 characters or less, and be a clear summary of the commit, e.g. "Fix Nokogiri compile issue on macOS Sierra, GH #305".


### PR DESCRIPTION
This adds a new CONTRIBUTING.md file, per #806. I've kept it as concise as possible, since it gets shown to both bug reporters and potential contributors: it occurred to me that we could have a separate file to have more details on the development process without overloading people who just want to report an issue.

I've deliberately not included items that are being discussed on other tickets, or might need more work:

* Whether there should be a separate Security section, and if so, what contact information to give
* Coding style
* The testing process