### PR TITLE
Add Rubocop to Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,9 @@
 task :default => :tasklist
 
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
 desc 'Show Rake Tasks (`rake -T`)'
 task :tasklist do
   exec 'rake -T'


### PR DESCRIPTION
This just adds the built-in Rake tasks for Rubocop to the project Rakefile.