### PR TITLE
Add Aliyun OSS storage

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -44,8 +44,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency "json", "1.8.2"
   gem.add_dependency "dogapi", "1.11.0"
   gem.add_dependency "aws-ses", "0.5.0"
-  gem.add_dependency "qiniu", "6.5.1"
+  gem.add_dependency "qiniu", "6.8.0"
   gem.add_dependency "nokogiri", "~> 1.6.0"
+  gem.add_dependency "aliyun-sdk", "~> 0.3.7"
 
   gem.add_development_dependency "rubocop", "0.45.0"
   gem.add_development_dependency "rake"

--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -47,6 +47,7 @@ module Backup
     autoload :RSync,      File.join(STORAGE_PATH, "rsync")
     autoload :Local,      File.join(STORAGE_PATH, "local")
     autoload :Qiniu,      File.join(STORAGE_PATH, "qiniu")
+    autoload :AliyunOss,  File.join(STORAGE_PATH, "aliyun_oss")
   end
 
   ##

--- a/lib/backup/config/dsl.rb
+++ b/lib/backup/config/dsl.rb
@@ -28,7 +28,7 @@ module Backup
               ["MySQL", "PostgreSQL", "MongoDB", "Redis", "Riak", "OpenLDAP", "SQLite"],
               # Storages
               ["S3", "CloudFiles", "Ninefold", "Dropbox", "FTP",
-               "SFTP", "SCP", "RSync", "Local", "Qiniu"],
+               "SFTP", "SCP", "RSync", "Local", "Qiniu", "AliyunOss"],
               # Compressors
               ["Gzip", "Bzip2", "Custom", "Pbzip2", "Lzma"],
               # Encryptors

--- a/lib/backup/storage/aliyun_oss.rb
+++ b/lib/backup/storage/aliyun_oss.rb
@@ -1,4 +1,4 @@
-require 'aliyun/oss'
+require "aliyun/oss"
 
 module Backup
   module Storage
@@ -62,10 +62,11 @@ module Backup
       def client
         return @client if @client
 
-        @client =  Aliyun::OSS::Client.new(
+        puts endpoint
+        @client = Aliyun::OSS::Client.new(
           endpoint: endpoint,
           access_key_id: access_key,
-          access_key_secret: secret_key,
+          access_key_secret: secret_key
         )
       end
     end

--- a/lib/backup/storage/aliyun_oss.rb
+++ b/lib/backup/storage/aliyun_oss.rb
@@ -1,0 +1,73 @@
+require 'aliyun/oss'
+
+module Backup
+  module Storage
+    class AliyunOss < Base
+      include Storage::Cycler
+      class Error < Backup::Error; end
+
+      ##
+      # Aliyun OSS API credentials
+      attr_accessor :access_key, :secret_key
+
+      ##
+      # Aliyun OSS bucket name
+      attr_accessor :bucket
+
+      ##
+      # Aliyun OSS endpoint
+      attr_accessor :endpoint
+
+      def initialize(model, storage_id = nil)
+        super
+
+        @path ||= "backups"
+
+        check_configuration
+      end
+
+      private
+
+      def transfer!
+        package.filenames.each do |filename|
+          src = File.join(Config.tmp_path, filename)
+          dest = File.join(remote_path, filename)
+          Logger.info "Storing '#{dest}'..."
+
+          bucket_client = client.get_bucket(bucket)
+          bucket_client.put_object(dest, file: src)
+        end
+      end
+
+      # Called by the Cycler.
+      # Any error raised will be logged as a warning.
+      def remove!(package)
+        Logger.info "Removing backup package dated #{package.time}..."
+        remote_path = remote_path_for(package)
+        package.filenames.each do |filename|
+          bucket_client = client.get_bucket(bucket)
+          bucket_client.delete_object(File.join(remote_path, filename))
+        end
+      end
+
+      def check_configuration
+        required = %w(access_key secret_key bucket endpoint)
+
+        raise Error, <<-EOS if required.map { |name| send(name) }.any?(&:nil?)
+          Configuration Error
+          #{required.map { |name| "##{name}" }.join(", ")} are all required
+        EOS
+      end
+
+      def client
+        return @client if @client
+
+        @client =  Aliyun::OSS::Client.new(
+          endpoint: endpoint,
+          access_key_id: access_key,
+          access_key_secret: secret_key,
+        )
+      end
+    end
+  end
+end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -556,7 +556,7 @@ describe "Backup::CLI" do
     it "should include the correct option values" do
       options = <<-EOS.lines.to_a.map(&:strip).map { |l| l.partition(" ") }
         databases (mongodb, mysql, openldap, postgresql, redis, riak)
-        storages (cloud_files, dropbox, ftp, local, qiniu, rsync, s3, scp, sftp)
+        storages (aliyun_oss, cloud_files, dropbox, ftp, local, qiniu, rsync, s3, scp, sftp)
         syncers (cloud_files, rsync_local, rsync_pull, rsync_push, s3)
         encryptor (gpg, openssl)
         compressor (bzip2, custom, gzip)

--- a/spec/storage/aliyun_oss_spec.rb
+++ b/spec/storage/aliyun_oss_spec.rb
@@ -1,0 +1,115 @@
+require "spec_helper"
+
+module Backup
+  describe Storage::AliyunOss do
+    let(:model) { Model.new(:test_trigger, "test label") }
+    let(:required_config) do
+      proc do |oss|
+        oss.access_key = "my_access_key"
+        oss.secret_key = "my_secret_key"
+        oss.bucket     = "my_bucket"
+        oss.endpoint   = "my_endpoint"
+      end
+    end
+    let(:storage) { Storage::AliyunOss.new(model, &required_config) }
+    let(:s) { sequence "" }
+
+    describe "#initialize" do
+      it "provides default values" do
+        # required
+        expect(storage.bucket).to eq "my_bucket"
+        expect(storage.access_key).to eq "my_access_key"
+        expect(storage.secret_key).to eq "my_secret_key"
+        expect(storage.endpoint).to eq "my_endpoint"
+
+        # defaults
+        expect(storage.storage_id).to be_nil
+        expect(storage.keep).to be_nil
+        expect(storage.path).to eq "backups"
+      end
+
+      it "requires access_key secret_key and bucket" do
+        expect do
+          Storage::AliyunOss.new(model)
+        end.to raise_error { |err|
+          expect(err.message).to match(/#access_key, #secret_key, #bucket, #endpoint are all required/)
+        }
+      end
+    end
+
+    it "#client" do
+      ::Aliyun::OSS::Client.expects(:new).with(endpoint: 'my_endpoint', access_key_id: "my_access_key", access_key_secret: "my_secret_key")
+
+      pre_config = required_config
+      storage = Storage::AliyunOss.new(model) do |qiniu|
+        pre_config.call(qiniu)
+      end
+      storage.instance_eval { client }
+    end
+
+    describe "#transfer!" do
+      let(:timestamp) { Time.now.strftime("%Y.%m.%d.%H.%M.%S") }
+      let(:remote_path) { File.join("my/path/test_trigger", timestamp) }
+      let(:uptoken) { "uptoken" }
+
+      before do
+        Timecop.freeze
+        storage.package.time = timestamp
+        storage.package.stubs(:filenames).returns(
+          ["test_trigger.tar-aa", "test_trigger.tar-ab"]
+        )
+        storage.path = "my/path"
+      end
+
+      after { Timecop.return }
+
+      it "transfers the package files" do
+        src = File.join(Config.tmp_path, "test_trigger.tar-aa")
+        dest = File.join(remote_path, "test_trigger.tar-aa")
+
+        Logger.expects(:info).in_sequence(s).with("Storing '#{dest}'...")
+        Aliyun::OSS::Bucket.any_instance.expects(:put_object).with(dest, file: src)
+
+        src = File.join(Config.tmp_path, "test_trigger.tar-ab")
+        dest = File.join(remote_path, "test_trigger.tar-ab")
+
+        Logger.expects(:info).in_sequence(s).with("Storing '#{dest}'...")
+        Aliyun::OSS::Bucket.any_instance.expects(:put_object).with(dest, file: src)
+
+        storage.send(:transfer!)
+      end
+    end
+
+    describe "#remove" do
+      let(:timestamp) { Time.now.strftime("%Y.%m.%d.%H.%M.%S") }
+      let(:remote_path) { File.join("my/path/test_trigger", timestamp) }
+      let(:uptoken) { "uptoken" }
+      let(:package) do
+        stub( # loaded from YAML storage file
+          trigger: "test_trigger",
+          time: timestamp,
+          filenames: ["test_trigger.tar-aa", "test_trigger.tar-ab"]
+        )
+      end
+
+      before do
+        Timecop.freeze
+        storage.path = "my/path"
+      end
+
+      after { Timecop.return }
+
+      it "removes the given package from the remote" do
+        Logger.expects(:info).in_sequence(s).with("Removing backup package dated #{timestamp}...")
+
+        dest = File.join(remote_path, "test_trigger.tar-aa")
+        Aliyun::OSS::Bucket.any_instance.expects(:delete_object).with(dest)
+
+        dest = File.join(remote_path, "test_trigger.tar-ab")
+        Aliyun::OSS::Bucket.any_instance.expects(:delete_object).with(dest)
+
+        storage.send(:remove!, package)
+      end
+    end
+  end
+end

--- a/spec/storage/aliyun_oss_spec.rb
+++ b/spec/storage/aliyun_oss_spec.rb
@@ -8,7 +8,7 @@ module Backup
         oss.access_key = "my_access_key"
         oss.secret_key = "my_secret_key"
         oss.bucket     = "my_bucket"
-        oss.endpoint   = "my_endpoint"
+        oss.endpoint   = "endpoint.test"
       end
     end
     let(:storage) { Storage::AliyunOss.new(model, &required_config) }
@@ -20,7 +20,7 @@ module Backup
         expect(storage.bucket).to eq "my_bucket"
         expect(storage.access_key).to eq "my_access_key"
         expect(storage.secret_key).to eq "my_secret_key"
-        expect(storage.endpoint).to eq "my_endpoint"
+        expect(storage.endpoint).to eq "endpoint.test"
 
         # defaults
         expect(storage.storage_id).to be_nil
@@ -38,7 +38,11 @@ module Backup
     end
 
     it "#client" do
-      ::Aliyun::OSS::Client.expects(:new).with(endpoint: 'my_endpoint', access_key_id: "my_access_key", access_key_secret: "my_secret_key")
+      ::Aliyun::OSS::Client.expects(:new).with(
+        endpoint: "endpoint.test",
+        access_key_id: "my_access_key",
+        access_key_secret: "my_secret_key"
+      )
 
       pre_config = required_config
       storage = Storage::AliyunOss.new(model) do |qiniu|

--- a/templates/cli/storages/aliyun_oss
+++ b/templates/cli/storages/aliyun_oss
@@ -1,0 +1,14 @@
+##
+# Aliyun OSS [Storage]
+#
+store_with AliyunOSS do |oss|
+  # Qiniu Credentials
+  oss.access_key = "my_access_key"
+  oss.secret_key = "my_secret_key"
+
+  oss.bucket     = "bucket-name"
+  # More options see this https://help.aliyun.com/document_detail/31837.html
+  oss.endpoint   = "your_region.aliyuncs.com"
+  qiniu.keep     = 5
+  qiniu.path     = "path/to/backups"
+en


### PR DESCRIPTION
This is same with #419. Supports [Aliyun OSS](https://www.aliyun.com/product/oss/) storage. Aliyun OSS is more popular and faster than s3 or dropbox in China.

More details, I upgrade the `qiniu` gem because `qiniu` is conflict with `aliyun-sdk` on `rest-client` dependency gem.