### PR TITLE
Swap Notifier::Ses to use `aws-sdk` gem and add support for IAM instance profiles

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -36,13 +36,13 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-ssh", "3.2.0"
   gem.add_dependency "net-scp", "1.2.1"
   gem.add_dependency "net-sftp", "2.1.2"
-  gem.add_dependency "mail", "2.6.3" # patched
+  gem.add_dependency "mail", "2.6.5" # patched
   gem.add_dependency "pagerduty", "2.0.0"
   gem.add_dependency "twitter", "~> 5.5"
   gem.add_dependency "hipchat", "1.0.1"
   gem.add_dependency "flowdock", "0.4.0"
   gem.add_dependency "dogapi", "1.11.0"
-  gem.add_dependency "aws-ses", "0.5.0"
+  gem.add_dependency "aws-sdk", "~> 2"
   gem.add_dependency "qiniu", "~> 6.5"
   gem.add_dependency "nokogiri", "~> 1.7", ">= 1.7.1"
 

--- a/lib/backup/notifier/mail.rb
+++ b/lib/backup/notifier/mail.rb
@@ -238,7 +238,7 @@ module Mail
   class Exim
     def self.call(path, arguments, _destinations, encoded_message)
       popen "#{path} #{arguments}" do |io|
-        io.puts encoded_message.to_lf
+        io.puts ::Mail::Utilities.to_lf(encoded_message)
         io.flush
       end
     end

--- a/spec/notifier/ses_spec.rb
+++ b/spec/notifier/ses_spec.rb
@@ -56,48 +56,88 @@ module Backup
     end
 
     describe "#notify!" do
-      let(:fake_ses) { Object.new }
-      let(:notifier) do
-        f = fake_ses
-        Notifier::Ses.new(model) do |ses|
-          ses.access_key_id = "my_access_key_id"
-          ses.secret_access_key = "my_secret_access_key"
-          ses.stubs(:client).returns(f)
+      let(:fake_ses) { Aws::SES::Client.new(stub_responses: true) }
+
+      shared_examples "messages" do
+        context "when status is :success" do
+          it "sends a success message" do
+            fake_ses.expects(:send_raw_email).once.with do |send_opts|
+              mail = ::Mail.new(send_opts[:raw_message][:data])
+              expect(mail.subject).to eq("[Backup::Success] test label (test_trigger)")
+              expect(mail.body.raw_source).to match_regex("Backup Completed Successfully!")
+              expect(mail.to).to eq ["my.receiver.email@gmail.com"]
+              expect(mail.from).to eq ["my.sender.email@gmail.com"]
+              expect(mail.cc).to eq ["my.cc.email@gmail.com"]
+              expect(mail.bcc).to eq ["my.bcc.email@gmail.com"]
+              expect(mail.reply_to).to eq ["my.reply_to.email@gmail.com"]
+              expect(mail.destinations).to eq send_opts[:destinations]
+            end
+
+            notifier.send(:notify!, :success)
+          end
+        end
+
+        context "when status is :warning" do
+          it "sends a warning message" do
+            fake_ses.expects(:send_raw_email).once.with do |send_opts|
+              mail = ::Mail.new(send_opts[:raw_message][:data])
+              expect(mail.subject).to eq("[Backup::Warning] test label (test_trigger)")
+              expect(mail.parts[0].body.raw_source).to match_regex("with Warnings")
+              expect(mail.attachments[0].filename).to match_regex("log")
+              expect(mail.destinations).to eq send_opts[:destinations]
+            end
+
+            notifier.send(:notify!, :warning)
+          end
+        end
+
+        context "when status is :failure" do
+          it "sends a failure message" do
+            fake_ses.expects(:send_raw_email).once.with do |send_opts|
+              mail = ::Mail.new(send_opts[:raw_message][:data])
+              expect(mail.subject).to eq("[Backup::Failure] test label (test_trigger)")
+              expect(mail.parts[0].body.raw_source).to match_regex("Backup Failed!")
+              expect(mail.attachments[0].filename).to match_regex("log")
+              expect(mail.destinations).to eq send_opts[:destinations]
+            end
+
+            notifier.send(:notify!, :failure)
+          end
         end
       end
 
-      context "when status is :success" do
-        it "sends a success message" do
-          fake_ses.expects(:send_raw_email).once.with do |mail|
-            expect(mail.subject).to eq("[Backup::Success] test label (test_trigger)")
-            expect(mail.body.raw_source).to match_regex("Backup Completed Successfully!")
+      context "uses access key id" do
+        it_behaves_like "messages" do
+          let(:notifier) do
+            f = fake_ses
+            Notifier::Ses.new(model) do |ses|
+              ses.access_key_id = "my_access_key_id"
+              ses.secret_access_key = "my_secret_access_key"
+              ses.to = "my.receiver.email@gmail.com"
+              ses.from = "my.sender.email@gmail.com"
+              ses.cc = "my.cc.email@gmail.com"
+              ses.bcc = "my.bcc.email@gmail.com"
+              ses.reply_to = "my.reply_to.email@gmail.com"
+              ses.stubs(:client).returns(f)
+            end
           end
-
-          notifier.send(:notify!, :success)
         end
       end
 
-      context "when status is :warning" do
-        it "sends a warning message" do
-          fake_ses.expects(:send_raw_email).once.with do |mail|
-            expect(mail.subject).to eq("[Backup::Warning] test label (test_trigger)")
-            expect(mail.parts[0].body.raw_source).to match_regex("with Warnings")
-            expect(mail.attachments[0].filename).to match_regex("log")
+      context "uses iam instance profile" do
+        it_behaves_like "messages" do
+          let(:notifier) do
+            f = fake_ses
+            Notifier::Ses.new(model) do |ses|
+              ses.use_iam_profile = true
+              ses.to = "my.receiver.email@gmail.com"
+              ses.from = "my.sender.email@gmail.com"
+              ses.cc = "my.cc.email@gmail.com"
+              ses.bcc = "my.bcc.email@gmail.com"
+              ses.reply_to = "my.reply_to.email@gmail.com"
+              ses.stubs(:client).returns(f)
+            end
           end
-
-          notifier.send(:notify!, :warning)
-        end
-      end
-
-      context "when status is :failure" do
-        it "sends a failure message" do
-          fake_ses.expects(:send_raw_email).once.with do |mail|
-            expect(mail.subject).to eq("[Backup::Failure] test label (test_trigger)")
-            expect(mail.parts[0].body.raw_source).to match_regex("Backup Failed!")
-            expect(mail.attachments[0].filename).to match_regex("log")
-          end
-
-          notifier.send(:notify!, :failure)
         end
       end
     end


### PR DESCRIPTION
Sadly, the `aws-ses` gem doesn't support IAM instance profiles, so just swap it out for the official `aws-sdk` gem.

Fixes #666.