### PR TITLE
Adding Azure Storage support for Ruby > 2.0

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0"
 
-  gem.add_dependency "thor", "0.18.1"
+  gem.add_dependency "thor", "0.19.0"
   gem.add_dependency "open4", "1.3.0"
   gem.add_dependency "fog", "1.28.0"
   gem.add_dependency "excon", "~> 0.44"
@@ -46,6 +46,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "aws-ses", "0.5.0"
   gem.add_dependency "qiniu", "6.5.1"
   gem.add_dependency "nokogiri", "~> 1.6.0"
+  gem.add_dependency "azure", "~> 0.7.7"
 
   gem.add_development_dependency "rubocop", "0.45.0"
   gem.add_development_dependency "rake"

--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -47,6 +47,7 @@ module Backup
     autoload :RSync,      File.join(STORAGE_PATH, "rsync")
     autoload :Local,      File.join(STORAGE_PATH, "local")
     autoload :Qiniu,      File.join(STORAGE_PATH, "qiniu")
+    autoload :AzureStore, File.join(STORAGE_PATH, "azure_store")
   end
 
   ##

--- a/lib/backup/config/dsl.rb
+++ b/lib/backup/config/dsl.rb
@@ -28,7 +28,7 @@ module Backup
               ["MySQL", "PostgreSQL", "MongoDB", "Redis", "Riak", "OpenLDAP", "SQLite"],
               # Storages
               ["S3", "CloudFiles", "Ninefold", "Dropbox", "FTP",
-               "SFTP", "SCP", "RSync", "Local", "Qiniu"],
+               "SFTP", "SCP", "RSync", "Local", "Qiniu", "AzureStore"],
               # Compressors
               ["Gzip", "Bzip2", "Custom", "Pbzip2", "Lzma"],
               # Encryptors

--- a/lib/backup/storage/azure_store.rb
+++ b/lib/backup/storage/azure_store.rb
@@ -1,0 +1,77 @@
+# encoding: utf-8
+require 'azure'
+
+module Backup
+  module Storage
+    class AzureStore < Base
+      include Storage::Cycler
+      class Error < Backup::Error; end
+
+      # Azure credentials
+      attr_accessor :storage_account, :storage_access_key
+
+      # Azure Storage Container
+      attr_accessor :container_name, :container
+      attr_accessor :blob_service, :chunk_size
+
+      def initialize(model, storage_id = nil)
+        super
+        @path       ||= 'backups'
+        @chunk_size ||= 1024 * 1024 * 4 # bytes
+        path.sub!(/^\//, '')
+
+        #check_configuration
+
+        Azure.config.storage_account_name = storage_account
+        Azure.config.storage_access_key = storage_access_key
+      end
+
+      def azure_blob_service
+        @blob_service ||= Azure::Blob::BlobService.new
+      end
+
+      def azure_container
+        @azure_container ||= azure_blob_service.get_container_properties(container_name)
+      end
+
+      def transfer!
+        package.filenames.each do |filename|
+          src = File.join(Config.tmp_path, filename)
+          dest = File.join(remote_path, filename)
+          Logger.info "Creating Block Blob '#{ azure_container.name }/#{ dest }'..."
+          blob = blob_service.create_block_blob(@azure_container.name, dest, "")
+          chunk_ids = []
+
+          File.open(src, "r") do |fh_in|
+            until fh_in.eof?
+              chunk = "#{"%05d"%(fh_in.pos/chunk_size)}"
+              Logger.info "Storing blob '#{ blob.name }/#{ chunk }'..."
+              azure_blob_service.create_blob_block(azure_container.name, blob.name, chunk, fh_in.read(chunk_size))
+              chunk_ids.push([chunk])
+            end
+          end
+          azure_blob_service.commit_blob_blocks(azure_container.name, blob.name, chunk_ids)
+        end
+      end
+
+      # Called by the Cycler.
+      # Any error raised will be logged as a warning.
+      def remove!(package)
+        Logger.info "Removing backup package dated #{package.time}..."
+
+        package.filenames.each do |filename|
+          azure_blob_service.delete_blob(azure_container.name, "#{remote_path_for(package)}/#{filename}")
+        end
+      end
+
+      def check_configuration
+        required = %w(storage_account storage_access_key)
+
+        raise Error, <<-EOS if required.map {|name| send(name) }.any?(&:nil?)
+          Configuration Error
+          #{ required.map {|name| "##{ name }"}.join(', ') } are all required
+        EOS
+      end
+    end
+  end
+end

--- a/spec/storage/azure_storage_spec.rb
+++ b/spec/storage/azure_storage_spec.rb
@@ -1,0 +1,40 @@
+# encoding: utf-8
+
+require File.expand_path('../../spec_helper.rb', __FILE__)
+
+module Backup
+  describe Storage::AzureStore do
+    let(:model) { Model.new(:test_trigger, 'test label') }
+    let(:storage) { Storage::AzureStore.new(model) }
+
+    it_behaves_like 'a class that includes Config::Helpers'
+    it_behaves_like 'a subclass of Storage::Base'
+
+    describe '#initialize' do
+      it 'provides default values' do
+        expect( storage.storage_account    ).to be_nil
+        expect( storage.storage_access_key ).to be_nil
+        expect( storage.container_name     ).to be_nil
+        expect( storage.blob_service       ).to be_nil
+        expect( storage.chunk_size         ).to be 1024 * 1024 * 4
+        expect( storage.path               ).to eq 'backups'
+      end
+
+      it 'configures the storage' do
+        storage = Storage::AzureStore.new(model, :my_id) do |db|
+          db.storage_account    = 'my_storage_account'
+          db.storage_access_key = 'my_storage_access_key'
+          db.container_name     = 'my_container'
+          db.chunk_size         = 1024
+          db.path               = 'my/path'
+        end
+
+        expect( storage.storage_account       ).to eq 'my_storage_account'
+        expect( storage.storage_access_key    ).to eq 'my_storage_access_key'
+        expect( storage.container_name        ).to eq 'my_container'
+        expect( storage.chunk_size            ).to eq 1024
+        expect( storage.path                  ).to eq 'my/path'
+      end
+    end # describe '#initialize'
+  end
+end

--- a/spec/storage/azure_storage_spec.rb
+++ b/spec/storage/azure_storage_spec.rb
@@ -1,39 +1,46 @@
 # encoding: utf-8
 
-require File.expand_path('../../spec_helper.rb', __FILE__)
+require File.expand_path("../../spec_helper.rb", __FILE__)
 
 module Backup
   describe Storage::AzureStore do
-    let(:model) { Model.new(:test_trigger, 'test label') }
-    let(:storage) { Storage::AzureStore.new(model) }
+    let(:model) { Model.new(:test_trigger, "test label") }
+    let(:required_config) do
+      proc do |cf|
+        cf.storage_account = "my_storage_account"
+        cf.storage_access_key = "my_storage_access_key"
+        cf.container_name = "my_container"
+      end
+    end
+    let(:storage) { Storage::AzureStore.new(model, &required_config) }
 
-    it_behaves_like 'a class that includes Config::Helpers'
-    it_behaves_like 'a subclass of Storage::Base'
+    it_behaves_like "a class that includes Config::Helpers"
+    it_behaves_like "a subclass of Storage::Base"
 
-    describe '#initialize' do
-      it 'provides default values' do
-        expect( storage.storage_account    ).to be_nil
-        expect( storage.storage_access_key ).to be_nil
-        expect( storage.container_name     ).to be_nil
-        expect( storage.blob_service       ).to be_nil
-        expect( storage.chunk_size         ).to be 1024 * 1024 * 4
-        expect( storage.path               ).to eq 'backups'
+    describe "#initialize" do
+      it "provides default values" do
+        expect(storage.storage_account).to eq("my_storage_account")
+        expect(storage.storage_access_key).to eq("my_storage_access_key")
+        expect(storage.container_name).to eq("my_container")
+        expect(storage.blob_service).to be_nil
+        expect(storage.chunk_size).to be 1024 * 1024 * 4
+        expect(storage.path).to eq "backups"
       end
 
-      it 'configures the storage' do
+      it "configures the storage" do
         storage = Storage::AzureStore.new(model, :my_id) do |db|
-          db.storage_account    = 'my_storage_account'
-          db.storage_access_key = 'my_storage_access_key'
-          db.container_name     = 'my_container'
+          db.storage_account    = "my_configured_storage_account"
+          db.storage_access_key = "my_configured_storage_access_key"
+          db.container_name     = "my_configured_container"
           db.chunk_size         = 1024
-          db.path               = 'my/path'
+          db.path               = "/my/path"
         end
 
-        expect( storage.storage_account       ).to eq 'my_storage_account'
-        expect( storage.storage_access_key    ).to eq 'my_storage_access_key'
-        expect( storage.container_name        ).to eq 'my_container'
-        expect( storage.chunk_size            ).to eq 1024
-        expect( storage.path                  ).to eq 'my/path'
+        expect(storage.storage_account).to eq "my_configured_storage_account"
+        expect(storage.storage_access_key).to eq "my_configured_storage_access_key"
+        expect(storage.container_name).to eq "my_configured_container"
+        expect(storage.chunk_size).to eq 1024
+        expect(storage.path).to eq "my/path"
       end
     end # describe '#initialize'
   end


### PR DESCRIPTION
Based on the work of https://github.com/backup/backup/pull/532, this enables storage support for [Azure Blob Storage](https://azure.microsoft.com/de-de/services/storage/blobs/), using the [Azure gem](https://rubygems.org/gems/azure) - which only supports Ruby > 2.

I think the implementation could also be using the Fog provider with the support of [Fog Azure RM](https://github.com/fog/fog-azure-rm/blob/master/lib/fog/azurerm/docs/storage.md), but I opted for this version, because it's using less dependencies.

For the documentation the minimum requirements are:

```ruby
store_with AzureStore do |storage|
  storage.storage_account = 'my_storage_account'
  storage.storage_access_key = 'my_storage_access_key'
  storage.container_name = "my_container"
end
```

This is tested on Mac OS X 10.11.6 with Ruby 2.3.3. It's also running on Ubuntu 16.04.2 LTS with Ruby 2.3.1.