### PR TITLE
Bump nokogiri to 1.7.1

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0"
 
-  gem.add_dependency "thor", "0.18.1"
+  gem.add_dependency "thor", "~> 0.18", ">= 0.18.1"
   gem.add_dependency "open4", "1.3.0"
   gem.add_dependency "fog", "~> 1.28"
   gem.add_dependency "excon", "~> 0.44"
@@ -38,13 +38,13 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-sftp", "2.1.2"
   gem.add_dependency "mail", "2.6.3" # patched
   gem.add_dependency "pagerduty", "2.0.0"
-  gem.add_dependency "twitter", "5.5.0"
+  gem.add_dependency "twitter", "~> 5.5"
   gem.add_dependency "hipchat", "1.0.1"
   gem.add_dependency "flowdock", "0.4.0"
   gem.add_dependency "dogapi", "1.11.0"
   gem.add_dependency "aws-ses", "0.5.0"
   gem.add_dependency "qiniu", "~> 6.5"
-  gem.add_dependency "nokogiri", "~> 1.6"
+  gem.add_dependency "nokogiri", "~> 1.7", ">= 1.7.1"
 
   gem.add_development_dependency "rubocop", "0.45.0"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
CVE-2016-4658 and CVE-2016-5131 [were fixed in nokogiri 1.7.1](https://github.com/sparklemotion/nokogiri/issues/1615).

Loosen dependency for:
 - thor
 - json
 - nokogiri
 - twitter (http gem CVE-2015-1828)
 - qiniu (rest-client CVE-2015-1820)