### PR TITLE
RSpec upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "transpec"
-
 # Omitted from CI Environment
 group :no_ci do
   gem "rb-fsevent" # Mac OS X

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "transpec"
+
 # Omitted from CI Environment
 group :no_ci do
   gem "rb-fsevent" # Mac OS X

--- a/backup.gemspec
+++ b/backup.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rubocop", "0.45.0"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec", "2.14.1"
+  gem.add_development_dependency "rspec", "2.99.0"
   gem.add_development_dependency "mocha", "0.14.0"
   gem.add_development_dependency "timecop", "0.7.1"
 end

--- a/backup.gemspec
+++ b/backup.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rubocop", "0.45.0"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec", "2.99.0"
+  gem.add_development_dependency "rspec", "3.5.0"
   gem.add_development_dependency "mocha", "0.14.0"
   gem.add_development_dependency "timecop", "0.7.1"
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -33,10 +33,10 @@ describe "Backup::CLI" do
           cli.start
         end.not_to raise_error
 
-        logger_options.console.quiet.should be(false)
-        logger_options.logfile.enabled.should be_true
-        logger_options.logfile.log_path.should == ""
-        logger_options.syslog.enabled.should be(false)
+        expect(logger_options.console.quiet).to be(false)
+        expect(logger_options.logfile.enabled).to eq(true)
+        expect(logger_options.logfile.log_path).to eq("")
+        expect(logger_options.syslog.enabled).to be(false)
       end
 
       it "configures only the syslog" do
@@ -48,10 +48,10 @@ describe "Backup::CLI" do
           cli.start
         end.not_to raise_error
 
-        logger_options.console.quiet.should be_true
-        logger_options.logfile.enabled.should be_nil
-        logger_options.logfile.log_path.should == ""
-        logger_options.syslog.enabled.should be_true
+        expect(logger_options.console.quiet).to be_truthy
+        expect(logger_options.logfile.enabled).to be_nil
+        expect(logger_options.logfile.log_path).to eq("")
+        expect(logger_options.syslog.enabled).to be_truthy
       end
 
       it "forces console logging" do
@@ -62,10 +62,10 @@ describe "Backup::CLI" do
           cli.start
         end.not_to raise_error
 
-        logger_options.console.quiet.should be_nil
-        logger_options.logfile.enabled.should be_true
-        logger_options.logfile.log_path.should == ""
-        logger_options.syslog.enabled.should be(false)
+        expect(logger_options.console.quiet).to be_nil
+        expect(logger_options.logfile.enabled).to eq(true)
+        expect(logger_options.logfile.log_path).to eq("")
+        expect(logger_options.syslog.enabled).to be(false)
       end
 
       it "forces the logfile and syslog to be disabled" do
@@ -77,10 +77,10 @@ describe "Backup::CLI" do
           cli.start
         end.not_to raise_error
 
-        logger_options.console.quiet.should be(false)
-        logger_options.logfile.enabled.should be_nil
-        logger_options.logfile.log_path.should == ""
-        logger_options.syslog.enabled.should be_nil
+        expect(logger_options.console.quiet).to be(false)
+        expect(logger_options.logfile.enabled).to be_nil
+        expect(logger_options.logfile.log_path).to eq("")
+        expect(logger_options.syslog.enabled).to be_nil
       end
 
       it "configures the log_path" do
@@ -92,10 +92,10 @@ describe "Backup::CLI" do
           cli.start
         end.not_to raise_error
 
-        logger_options.console.quiet.should be(false)
-        logger_options.logfile.enabled.should be_true
-        logger_options.logfile.log_path.should == "my/log/path"
-        logger_options.syslog.enabled.should be(false)
+        expect(logger_options.console.quiet).to be(false)
+        expect(logger_options.logfile.enabled).to eq(true)
+        expect(logger_options.logfile.log_path).to eq("my/log/path")
+        expect(logger_options.syslog.enabled).to be(false)
       end
     end # describe 'setting logger options'
 
@@ -201,10 +201,10 @@ describe "Backup::CLI" do
         it "aborts with status code 3 and logs messages to the console only" do
           expectations = [
             proc do |err|
-              err.should be_a(Backup::CLI::Error)
-              err.message.should match(/config load error/)
+              expect(err).to be_a(Backup::CLI::Error)
+              expect(err.message).to match(/config load error/)
             end,
-            proc { |err| err.should be_a(String) }
+            proc { |err| expect(err).to be_a(String) }
           ]
           Backup::Logger.expects(:error).in_sequence(s).times(2).with do |err|
             expectation = expectations.shift
@@ -218,7 +218,7 @@ describe "Backup::CLI" do
               ["perform", "-t", "test_trigger_a"]
             )
             cli.start
-          end.to raise_error(SystemExit) { |exit| exit.status.should be(3) }
+          end.to raise_error(SystemExit) { |exit| expect(exit.status).to be(3) }
         end
       end
 
@@ -229,8 +229,8 @@ describe "Backup::CLI" do
 
         it "aborts and logs messages to the console only" do
           Backup::Logger.expects(:error).in_sequence(s).with do |err|
-            err.should be_a(Backup::CLI::Error)
-            err.message.should match(
+            expect(err).to be_a(Backup::CLI::Error)
+            expect(err.message).to match(
               /No Models found for trigger\(s\) 'test_trigger_foo'/
             )
           end
@@ -242,7 +242,7 @@ describe "Backup::CLI" do
               ["perform", "-t", "test_trigger_foo"]
             )
             cli.start
-          end.to raise_error(SystemExit) { |exit| exit.status.should be(3) }
+          end.to raise_error(SystemExit) { |exit| expect(exit.status).to be(3) }
         end
       end
     end # describe 'failure to prepare for backups'
@@ -299,7 +299,7 @@ describe "Backup::CLI" do
             ["perform", "-t", "test_trigger_a,test_trigger_b"]
           )
           cli.start
-        end.to raise_error(SystemExit) { |err| err.status.should be(1) }
+        end.to raise_error(SystemExit) { |err| expect(err.status).to be(1) }
       end
 
       specify "when a job has non-fatal errors" do
@@ -321,7 +321,7 @@ describe "Backup::CLI" do
             ["perform", "-t", "test_trigger_a,test_trigger_b"]
           )
           cli.start
-        end.to raise_error(SystemExit) { |err| err.status.should be(2) }
+        end.to raise_error(SystemExit) { |err| expect(err.status).to be(2) }
       end
 
       specify "when a job has fatal errors" do
@@ -340,7 +340,7 @@ describe "Backup::CLI" do
             ["perform", "-t", "test_trigger_a,test_trigger_b"]
           )
           cli.start
-        end.to raise_error(SystemExit) { |err| err.status.should be(3) }
+        end.to raise_error(SystemExit) { |err| expect(err.status).to be(3) }
       end
 
       specify "when jobs have errors and warnings" do
@@ -362,7 +362,7 @@ describe "Backup::CLI" do
             ["perform", "-t", "test_trigger_a,test_trigger_b"]
           )
           cli.start
-        end.to raise_error(SystemExit) { |err| err.status.should be(2) }
+        end.to raise_error(SystemExit) { |err| expect(err.status).to be(2) }
       end
     end # describe 'exit codes and notifications'
 
@@ -467,11 +467,11 @@ describe "Backup::CLI" do
               cli.start
             end
 
-            err.should be_empty
-            out.should == "Generated configuration file: '#{config_file}'.\n" \
-                          "Generated model file: '#{model_file}'.\n"
-            File.exist?(model_file).should be_true
-            File.exist?(config_file).should be_true
+            expect(err).to be_empty
+            expect(out).to eq("Generated configuration file: '#{config_file}'.\n" \
+                          "Generated model file: '#{model_file}'.\n")
+            expect(File.exist?(model_file)).to eq(true)
+            expect(File.exist?(config_file)).to eq(true)
           end
         end
       end
@@ -497,9 +497,9 @@ describe "Backup::CLI" do
               cli.start
             end
 
-            err.should be_empty
-            out.should == "Generated model file: '#{model_file}'.\n"
-            File.exist?(model_file).should be_true
+            expect(err).to be_empty
+            expect(out).to eq("Generated model file: '#{model_file}'.\n")
+            expect(File.exist?(model_file)).to eq(true)
           end
         end
       end
@@ -524,9 +524,9 @@ describe "Backup::CLI" do
               cli.start
             end
 
-            err.should include("Do you want to overwrite?")
-            out.should == "Generated configuration file: '#{config_file}'.\n"
-            File.exist?(config_file).should be_true
+            expect(err).to include("Do you want to overwrite?")
+            expect(out).to eq("Generated configuration file: '#{config_file}'.\n")
+            expect(File.exist?(config_file)).to eq(true)
           end
         end
       end
@@ -544,11 +544,11 @@ describe "Backup::CLI" do
             cli.start
           end
 
-          err.should be_empty
-          out.should == "Generated configuration file: '#{config_file}'.\n" \
-                        "Generated model file: '#{model_file}'.\n"
-          File.exist?(model_file).should be_true
-          File.exist?(config_file).should be_true
+          expect(err).to be_empty
+          expect(out).to eq("Generated configuration file: '#{config_file}'.\n" \
+                        "Generated model file: '#{model_file}'.\n")
+          expect(File.exist?(model_file)).to eq(true)
+          expect(File.exist?(config_file)).to eq(true)
         end
       end
     end
@@ -596,9 +596,9 @@ describe "Backup::CLI" do
             cli.start
           end
 
-          err.should be_empty
-          out.should == "Generated configuration file: '#{config_file}'.\n"
-          File.exist?(config_file).should be_true
+          expect(err).to be_empty
+          expect(out).to eq("Generated configuration file: '#{config_file}'.\n")
+          expect(File.exist?(config_file)).to eq(true)
         end
       end
     end
@@ -614,9 +614,9 @@ describe "Backup::CLI" do
             cli.start
           end
 
-          err.should be_empty
-          out.should == "Generated configuration file: '#{config_file}'.\n"
-          File.exist?(config_file).should be_true
+          expect(err).to be_empty
+          expect(out).to eq("Generated configuration file: '#{config_file}'.\n")
+          expect(File.exist?(config_file)).to eq(true)
         end
       end
     end
@@ -636,8 +636,8 @@ describe "Backup::CLI" do
             cli.start
           end
 
-          err.should include("Do you want to overwrite?")
-          out.should be_empty
+          expect(err).to include("Do you want to overwrite?")
+          expect(out).to be_empty
         end
       end
     end
@@ -649,8 +649,8 @@ describe "Backup::CLI" do
       out, err = capture_io do
         cli.start
       end
-      err.should be_empty
-      out.should == "Backup #{Backup::VERSION}\n"
+      expect(err).to be_empty
+      expect(out).to eq("Backup #{Backup::VERSION}\n")
     end
 
     specify "using `backup -v`" do
@@ -658,8 +658,8 @@ describe "Backup::CLI" do
       out, err = capture_io do
         cli.start
       end
-      err.should be_empty
-      out.should == "Backup #{Backup::VERSION}\n"
+      expect(err).to be_empty
+      expect(out).to eq("Backup #{Backup::VERSION}\n")
     end
   end
 
@@ -674,7 +674,7 @@ describe "Backup::CLI" do
         )
         $stdin.expects(:gets).returns("yes\n")
 
-        expect(helpers.overwrite?("a/path")).to be_true
+        expect(helpers.overwrite?("a/path")).to be_truthy
       end
 
       it "prompts user and accepts cancelation" do
@@ -684,13 +684,13 @@ describe "Backup::CLI" do
         )
         $stdin.expects(:gets).returns("no\n")
 
-        expect(helpers.overwrite?("a/path")).to be_false
+        expect(helpers.overwrite?("a/path")).to be_falsy
       end
 
       it "returns true if path does not exist" do
         File.expects(:exist?).with("a/path").returns(false)
         $stderr.expects(:print).never
-        expect(helpers.overwrite?("a/path")).to be_true
+        expect(helpers.overwrite?("a/path")).to eq(true)
       end
     end
   end # describe 'Helpers'

--- a/spec/cloud_io/s3_spec.rb
+++ b/spec/cloud_io/s3_spec.rb
@@ -733,15 +733,16 @@ module Backup
       it "returns empty headers by default" do
         cloud_io.stubs(:encryption).returns(nil)
         cloud_io.stubs(:storage_class).returns(nil)
-        cloud_io.send(:headers).should == {}
+        expect(cloud_io.send(:headers)).to eq({})
       end
 
       it "returns headers for server-side encryption" do
         cloud_io.stubs(:storage_class).returns(nil)
         ["aes256", :aes256].each do |arg|
           cloud_io.stubs(:encryption).returns(arg)
-          cloud_io.send(:headers).should ==
+          expect(cloud_io.send(:headers)).to eq(
             { "x-amz-server-side-encryption" => "AES256" }
+          )
         end
       end
 
@@ -749,23 +750,25 @@ module Backup
         cloud_io.stubs(:encryption).returns(nil)
         ["reduced_redundancy", :reduced_redundancy].each do |arg|
           cloud_io.stubs(:storage_class).returns(arg)
-          cloud_io.send(:headers).should ==
+          expect(cloud_io.send(:headers)).to eq(
             { "x-amz-storage-class" => "REDUCED_REDUNDANCY" }
+          )
         end
       end
 
       it "returns headers for both" do
         cloud_io.stubs(:encryption).returns(:aes256)
         cloud_io.stubs(:storage_class).returns(:reduced_redundancy)
-        cloud_io.send(:headers).should ==
+        expect(cloud_io.send(:headers)).to eq(
           { "x-amz-server-side-encryption" => "AES256",
             "x-amz-storage-class" => "REDUCED_REDUNDANCY" }
+        )
       end
 
       it "returns empty headers for empty values" do
         cloud_io.stubs(:encryption).returns("")
         cloud_io.stubs(:storage_class).returns("")
-        cloud_io.send(:headers).should == {}
+        expect(cloud_io.send(:headers)).to eq({})
       end
     end # describe '#headers
 

--- a/spec/cloud_io/s3_spec.rb
+++ b/spec/cloud_io/s3_spec.rb
@@ -741,7 +741,7 @@ module Backup
         ["aes256", :aes256].each do |arg|
           cloud_io.stubs(:encryption).returns(arg)
           expect(cloud_io.send(:headers)).to eq(
-            { "x-amz-server-side-encryption" => "AES256" }
+            "x-amz-server-side-encryption" => "AES256"
           )
         end
       end
@@ -751,7 +751,7 @@ module Backup
         ["reduced_redundancy", :reduced_redundancy].each do |arg|
           cloud_io.stubs(:storage_class).returns(arg)
           expect(cloud_io.send(:headers)).to eq(
-            { "x-amz-storage-class" => "REDUCED_REDUNDANCY" }
+            "x-amz-storage-class" => "REDUCED_REDUNDANCY"
           )
         end
       end
@@ -760,8 +760,8 @@ module Backup
         cloud_io.stubs(:encryption).returns(:aes256)
         cloud_io.stubs(:storage_class).returns(:reduced_redundancy)
         expect(cloud_io.send(:headers)).to eq(
-          { "x-amz-server-side-encryption" => "AES256",
-            "x-amz-storage-class" => "REDUCED_REDUNDANCY" }
+          "x-amz-server-side-encryption" => "AES256",
+            "x-amz-storage-class" => "REDUCED_REDUNDANCY"
         )
       end
 

--- a/spec/compressor/base_spec.rb
+++ b/spec/compressor/base_spec.rb
@@ -4,13 +4,13 @@ describe Backup::Compressor::Base do
   let(:compressor) { Backup::Compressor::Base.new }
 
   it "should include Utilities::Helpers" do
-    Backup::Compressor::Base
-      .include?(Backup::Utilities::Helpers).should be_true
+    expect(Backup::Compressor::Base
+      .include?(Backup::Utilities::Helpers)).to eq(true)
   end
 
   it "should include Config::Helpers" do
-    Backup::Compressor::Base
-      .include?(Backup::Config::Helpers).should be_true
+    expect(Backup::Compressor::Base
+      .include?(Backup::Config::Helpers)).to eq(true)
   end
 
   describe "#compress_with" do
@@ -21,15 +21,15 @@ describe Backup::Compressor::Base do
       compressor.expects(:log!)
 
       compressor.compress_with do |cmd, ext|
-        cmd.should == "compressor command"
-        ext.should == "compressor extension"
+        expect(cmd).to eq("compressor command")
+        expect(ext).to eq("compressor extension")
       end
     end
   end
 
   describe "#compressor_name" do
     it "should return class name with Backup namespace removed" do
-      compressor.send(:compressor_name).should == "Compressor::Base"
+      expect(compressor.send(:compressor_name)).to eq("Compressor::Base")
     end
   end
 

--- a/spec/compressor/bzip2_spec.rb
+++ b/spec/compressor/bzip2_spec.rb
@@ -6,8 +6,8 @@ describe Backup::Compressor::Bzip2 do
   end
 
   it "should be a subclass of Compressor::Base" do
-    Backup::Compressor::Bzip2
-      .superclass.should == Backup::Compressor::Base
+    expect(Backup::Compressor::Bzip2
+      .superclass).to eq(Backup::Compressor::Base)
   end
 
   describe "#initialize" do
@@ -22,20 +22,20 @@ describe Backup::Compressor::Bzip2 do
 
     context "when no pre-configured defaults have been set" do
       it "should use default values" do
-        compressor.level.should be_false
+        expect(compressor.level).to eq(false)
 
-        compressor.instance_variable_get(:@cmd).should == "bzip2"
-        compressor.instance_variable_get(:@ext).should == ".bz2"
+        expect(compressor.instance_variable_get(:@cmd)).to eq("bzip2")
+        expect(compressor.instance_variable_get(:@ext)).to eq(".bz2")
       end
 
       it "should use the values given" do
         compressor = Backup::Compressor::Bzip2.new do |c|
           c.level = 5
         end
-        compressor.level.should == 5
+        expect(compressor.level).to eq(5)
 
-        compressor.instance_variable_get(:@cmd).should == "bzip2 -5"
-        compressor.instance_variable_get(:@ext).should == ".bz2"
+        expect(compressor.instance_variable_get(:@cmd)).to eq("bzip2 -5")
+        expect(compressor.instance_variable_get(:@ext)).to eq(".bz2")
       end
     end # context 'when no pre-configured defaults have been set'
 
@@ -47,20 +47,20 @@ describe Backup::Compressor::Bzip2 do
       end
 
       it "should use pre-configured defaults" do
-        compressor.level.should == 7
+        expect(compressor.level).to eq(7)
 
-        compressor.instance_variable_get(:@cmd).should == "bzip2 -7"
-        compressor.instance_variable_get(:@ext).should == ".bz2"
+        expect(compressor.instance_variable_get(:@cmd)).to eq("bzip2 -7")
+        expect(compressor.instance_variable_get(:@ext)).to eq(".bz2")
       end
 
       it "should override pre-configured defaults" do
         compressor = Backup::Compressor::Bzip2.new do |c|
           c.level = 6
         end
-        compressor.level.should == 6
+        expect(compressor.level).to eq(6)
 
-        compressor.instance_variable_get(:@cmd).should == "bzip2 -6"
-        compressor.instance_variable_get(:@ext).should == ".bz2"
+        expect(compressor.instance_variable_get(:@cmd)).to eq("bzip2 -6")
+        expect(compressor.instance_variable_get(:@ext)).to eq(".bz2")
       end
     end # context 'when pre-configured defaults have been set'
   end # describe '#initialize'

--- a/spec/compressor/custom_spec.rb
+++ b/spec/compressor/custom_spec.rb
@@ -13,8 +13,8 @@ describe Backup::Compressor::Custom do
   end
 
   it "should be a subclass of Compressor::Base" do
-    Backup::Compressor::Custom
-      .superclass.should == Backup::Compressor::Base
+    expect(Backup::Compressor::Custom
+      .superclass).to eq(Backup::Compressor::Base)
   end
 
   describe "#initialize" do
@@ -38,23 +38,23 @@ describe Backup::Compressor::Custom do
         c.extension = " my_extension "
       end
 
-      compressor.command.should   == " my_command --option foo "
-      compressor.extension.should == " my_extension "
+      expect(compressor.command).to   eq(" my_command --option foo ")
+      expect(compressor.extension).to eq(" my_extension ")
 
       compressor.expects(:log!)
       compressor.compress_with do |cmd, ext|
-        cmd.should == "/path/to/my_command --option foo"
-        ext.should == "my_extension"
+        expect(cmd).to eq("/path/to/my_command --option foo")
+        expect(ext).to eq("my_extension")
       end
     end
 
     context "when no pre-configured defaults have been set" do
       it "should use default values" do
-        compressor.command.should   be_nil
-        compressor.extension.should be_nil
+        expect(compressor.command).to   be_nil
+        expect(compressor.extension).to be_nil
 
-        compressor.instance_variable_get(:@cmd).should == "error"
-        compressor.instance_variable_get(:@ext).should == ""
+        expect(compressor.instance_variable_get(:@cmd)).to eq("error")
+        expect(compressor.instance_variable_get(:@ext)).to eq("")
       end
 
       it "should use the values given" do
@@ -63,11 +63,11 @@ describe Backup::Compressor::Custom do
           c.extension = "my_extension"
         end
 
-        compressor.command.should   == "my_command"
-        compressor.extension.should == "my_extension"
+        expect(compressor.command).to   eq("my_command")
+        expect(compressor.extension).to eq("my_extension")
 
-        compressor.instance_variable_get(:@cmd).should == "/path/to/my_command"
-        compressor.instance_variable_get(:@ext).should == "my_extension"
+        expect(compressor.instance_variable_get(:@cmd)).to eq("/path/to/my_command")
+        expect(compressor.instance_variable_get(:@ext)).to eq("my_extension")
       end
     end # context 'when no pre-configured defaults have been set'
 
@@ -80,11 +80,11 @@ describe Backup::Compressor::Custom do
       end
 
       it "should use pre-configured defaults" do
-        compressor.command.should   == "default_command"
-        compressor.extension.should == "default_extension"
+        expect(compressor.command).to   eq("default_command")
+        expect(compressor.extension).to eq("default_extension")
 
-        compressor.instance_variable_get(:@cmd).should == "/path/to/default_command"
-        compressor.instance_variable_get(:@ext).should == "default_extension"
+        expect(compressor.instance_variable_get(:@cmd)).to eq("/path/to/default_command")
+        expect(compressor.instance_variable_get(:@ext)).to eq("default_extension")
       end
 
       it "should override pre-configured defaults" do
@@ -93,11 +93,11 @@ describe Backup::Compressor::Custom do
           c.extension = "new_extension"
         end
 
-        compressor.command.should   == "new_command"
-        compressor.extension.should == "new_extension"
+        expect(compressor.command).to   eq("new_command")
+        expect(compressor.extension).to eq("new_extension")
 
-        compressor.instance_variable_get(:@cmd).should == "/path/to/new_command"
-        compressor.instance_variable_get(:@ext).should == "new_extension"
+        expect(compressor.instance_variable_get(:@cmd)).to eq("/path/to/new_command")
+        expect(compressor.instance_variable_get(:@ext)).to eq("new_extension")
       end
     end # context 'when pre-configured defaults have been set'
   end # describe '#initialize'

--- a/spec/compressor/custom_spec.rb
+++ b/spec/compressor/custom_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Backup::Compressor::Custom do
   let(:compressor) { Backup::Compressor::Custom.new }
 
-  before(:all) do
+  before(:context) do
     # Utilities::Helpers#utility will raise an error
     # if the command is invalid or not set
     Backup::Compressor::Custom.send(

--- a/spec/compressor/gzip_spec.rb
+++ b/spec/compressor/gzip_spec.rb
@@ -8,13 +8,13 @@ describe Backup::Compressor::Gzip do
   end
 
   it "should be a subclass of Compressor::Base" do
-    Backup::Compressor::Gzip
-      .superclass.should == Backup::Compressor::Base
+    expect(Backup::Compressor::Gzip
+      .superclass).to eq(Backup::Compressor::Base)
   end
 
   it "should be extended by Utilities::Helpers" do
-    Backup::Compressor::Gzip.instance_eval("class << self; self; end")
-      .should include(Backup::Utilities::Helpers)
+    expect(Backup::Compressor::Gzip.instance_eval("class << self; self; end"))
+      .to include(Backup::Utilities::Helpers)
   end
 
   describe ".has_rsyncable?" do
@@ -30,8 +30,8 @@ describe Backup::Compressor::Gzip do
       end
 
       it "returns true and caches the result" do
-        Backup::Compressor::Gzip.has_rsyncable?.should be(true)
-        Backup::Compressor::Gzip.has_rsyncable?.should be(true)
+        expect(Backup::Compressor::Gzip.has_rsyncable?).to be(true)
+        expect(Backup::Compressor::Gzip.has_rsyncable?).to be(true)
       end
     end
 
@@ -43,8 +43,8 @@ describe Backup::Compressor::Gzip do
       end
 
       it "returns false and caches the result" do
-        Backup::Compressor::Gzip.has_rsyncable?.should be(false)
-        Backup::Compressor::Gzip.has_rsyncable?.should be(false)
+        expect(Backup::Compressor::Gzip.has_rsyncable?).to be(false)
+        expect(Backup::Compressor::Gzip.has_rsyncable?).to be(false)
       end
     end
   end
@@ -56,12 +56,12 @@ describe Backup::Compressor::Gzip do
 
     context "when no pre-configured defaults have been set" do
       it "should use default values" do
-        compressor.level.should be(false)
-        compressor.rsyncable.should be(false)
+        expect(compressor.level).to be(false)
+        expect(compressor.rsyncable).to be(false)
 
         compressor.compress_with do |cmd, ext|
-          cmd.should == "gzip"
-          ext.should == ".gz"
+          expect(cmd).to eq("gzip")
+          expect(ext).to eq(".gz")
         end
       end
 
@@ -70,12 +70,12 @@ describe Backup::Compressor::Gzip do
           c.level = 5
           c.rsyncable = true
         end
-        compressor.level.should == 5
-        compressor.rsyncable.should be(true)
+        expect(compressor.level).to eq(5)
+        expect(compressor.rsyncable).to be(true)
 
         compressor.compress_with do |cmd, ext|
-          cmd.should == "gzip -5 --rsyncable"
-          ext.should == ".gz"
+          expect(cmd).to eq("gzip -5 --rsyncable")
+          expect(ext).to eq(".gz")
         end
       end
     end # context 'when no pre-configured defaults have been set'
@@ -89,12 +89,12 @@ describe Backup::Compressor::Gzip do
       end
 
       it "should use pre-configured defaults" do
-        compressor.level.should == 7
-        compressor.rsyncable.should be(true)
+        expect(compressor.level).to eq(7)
+        expect(compressor.rsyncable).to be(true)
 
         compressor.compress_with do |cmd, ext|
-          cmd.should == "gzip -7 --rsyncable"
-          ext.should == ".gz"
+          expect(cmd).to eq("gzip -7 --rsyncable")
+          expect(ext).to eq(".gz")
         end
       end
 
@@ -103,12 +103,12 @@ describe Backup::Compressor::Gzip do
           c.level = 6
           c.rsyncable = false
         end
-        compressor.level.should == 6
-        compressor.rsyncable.should be(false)
+        expect(compressor.level).to eq(6)
+        expect(compressor.rsyncable).to be(false)
 
         compressor.compress_with do |cmd, ext|
-          cmd.should == "gzip -6"
-          ext.should == ".gz"
+          expect(cmd).to eq("gzip -6")
+          expect(ext).to eq(".gz")
         end
       end
     end # context 'when pre-configured defaults have been set'
@@ -117,20 +117,20 @@ describe Backup::Compressor::Gzip do
       Backup::Compressor::Gzip.instance_variable_set(:@has_rsyncable, false)
 
       Backup::Logger.expects(:warn).with do |err|
-        err.should be_a(Backup::Compressor::Gzip::Error)
-        err.message.should match(/'rsyncable' option ignored/)
+        expect(err).to be_a(Backup::Compressor::Gzip::Error)
+        expect(err.message).to match(/'rsyncable' option ignored/)
       end
 
       compressor = Backup::Compressor::Gzip.new do |c|
         c.level = 5
         c.rsyncable = true
       end
-      compressor.level.should == 5
-      compressor.rsyncable.should be(true)
+      expect(compressor.level).to eq(5)
+      expect(compressor.rsyncable).to be(true)
 
       compressor.compress_with do |cmd, ext|
-        cmd.should == "gzip -5"
-        ext.should == ".gz"
+        expect(cmd).to eq("gzip -5")
+        expect(ext).to eq(".gz")
       end
     end
   end # describe '#initialize'

--- a/spec/config/dsl_spec.rb
+++ b/spec/config/dsl_spec.rb
@@ -7,13 +7,13 @@ module Backup
         described_class.constants.each do |const|
           described_class.send(:remove_const, const)
         end
-        described_class.constants.should be_empty
+        expect(described_class.constants).to be_empty
 
         load File.expand_path("../../../lib/backup/config/dsl.rb", __FILE__)
 
-        expect(described_class.const_defined?("MySQL")).to be_true
-        expect(described_class.const_defined?("RSync")).to be_true
-        expect(described_class::RSync.const_defined?("Local")).to be_true
+        expect(described_class.const_defined?("MySQL")).to eq(true)
+        expect(described_class.const_defined?("RSync")).to eq(true)
+        expect(described_class::RSync.const_defined?("Local")).to eq(true)
       end
     end
 
@@ -23,10 +23,10 @@ module Backup
       context "when given an array of constant names" do
         it "creates modules for the given scope" do
           described_class.send(:create_modules, TestScope, ["Foo", "Bar"])
-          TestScope.const_defined?("Foo").should be_true
-          TestScope.const_defined?("Bar").should be_true
-          TestScope::Foo.class.should == Module
-          TestScope::Bar.class.should == Module
+          expect(TestScope.const_defined?("Foo")).to eq(true)
+          expect(TestScope.const_defined?("Bar")).to eq(true)
+          expect(TestScope::Foo.class).to eq(Module)
+          expect(TestScope::Bar.class).to eq(Module)
         end
       end
 
@@ -41,11 +41,11 @@ module Backup
               }]
             }]
           )
-          TestScope.const_defined?("FooBar").should be_true
-          TestScope.const_defined?("LevelA").should be_true
-          TestScope::LevelA.const_defined?("NameA").should be_true
-          TestScope::LevelA.const_defined?("LevelB").should be_true
-          TestScope::LevelA::LevelB.const_defined?("NameB").should be_true
+          expect(TestScope.const_defined?("FooBar")).to eq(true)
+          expect(TestScope.const_defined?("LevelA")).to eq(true)
+          expect(TestScope::LevelA.const_defined?("NameA")).to eq(true)
+          expect(TestScope::LevelA.const_defined?("LevelB")).to eq(true)
+          expect(TestScope::LevelA::LevelB.const_defined?("NameB")).to eq(true)
         end
       end
     end
@@ -90,7 +90,7 @@ module Backup
         block = proc {}
         subject.preconfigure("MyBackup", &block)
         klass = described_class.const_get("MyBackup")
-        klass.superclass.should == Backup::Model
+        expect(klass.superclass).to eq(Backup::Model)
 
         expect do
           subject.preconfigure("MyBackup", &block)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -172,8 +172,8 @@ module Backup
 
       it "caches the hostname" do
         Utilities.expects(:run).once.with("/path/to/hostname").returns("my_hostname")
-        config.hostname.should == "my_hostname"
-        config.hostname.should == "my_hostname"
+        expect(config.hostname).to eq("my_hostname")
+        expect(config.hostname).to eq("my_hostname")
       end
     end
 
@@ -182,8 +182,8 @@ module Backup
         it "should return @root_path without requiring the path to exist" do
           File.expects(:directory?).never
           expect do
-            config.send(:set_root_path, config.root_path)
-              .should == config.root_path
+            expect(config.send(:set_root_path, config.root_path))
+              .to eq(config.root_path)
           end.not_to raise_error
         end
       end
@@ -191,16 +191,16 @@ module Backup
       context "when the given path exists" do
         it "should set and return the @root_path" do
           expect do
-            config.send(:set_root_path, Dir.pwd).should == Dir.pwd
+            expect(config.send(:set_root_path, Dir.pwd)).to eq(Dir.pwd)
           end.not_to raise_error
-          config.root_path.should == Dir.pwd
+          expect(config.root_path).to eq(Dir.pwd)
         end
 
         it "should expand relative paths" do
           expect do
-            config.send(:set_root_path, "").should == Dir.pwd
+            expect(config.send(:set_root_path, "")).to eq(Dir.pwd)
           end.not_to raise_error
-          config.root_path.should == Dir.pwd
+          expect(config.root_path).to eq(Dir.pwd)
         end
       end
 
@@ -210,9 +210,9 @@ module Backup
           expect do
             config.send(:set_root_path, "foo")
           end.to raise_error { |err|
-            err.should be_an_instance_of config::Error
-            err.message.should match(/Root Path Not Found/)
-            err.message.should match(/Path was: #{ path }/)
+            expect(err).to be_an_instance_of config::Error
+            expect(err.message).to match(/Root Path Not Found/)
+            expect(err.message).to match(/Path was: #{ path }/)
           }
         end
       end
@@ -231,10 +231,10 @@ module Backup
             path = File.expand_path("foo")
 
             config.send(:set_path_variable, "var", path, "none", "/root/path")
-            config.instance_variable_get(:@var).should == path
+            expect(config.instance_variable_get(:@var)).to eq(path)
 
             config.send(:set_path_variable, "var", path, "none", nil)
-            config.instance_variable_get(:@var).should == path
+            expect(config.instance_variable_get(:@var)).to eq(path)
           end
         end
 
@@ -242,7 +242,7 @@ module Backup
           context "when a root_path is given" do
             it "should append the path to the root_path" do
               config.send(:set_path_variable, "var", "foo", "none", "/root/path")
-              config.instance_variable_get(:@var).should == "/root/path/foo"
+              expect(config.instance_variable_get(:@var)).to eq("/root/path/foo")
             end
           end
           context "when a root_path is not given" do
@@ -250,7 +250,7 @@ module Backup
               path = File.expand_path("foo")
 
               config.send(:set_path_variable, "var", "foo", "none", false)
-              config.instance_variable_get(:@var).should == path
+              expect(config.instance_variable_get(:@var)).to eq(path)
             end
           end
         end
@@ -260,13 +260,13 @@ module Backup
         context "when a root_path is given" do
           it "should use the root_path with the given ending" do
             config.send(:set_path_variable, "var", nil, "ending", "/root/path")
-            config.instance_variable_get(:@var).should == "/root/path/ending"
+            expect(config.instance_variable_get(:@var)).to eq("/root/path/ending")
           end
         end
         context "when a root_path is not given" do
           it "should do nothing" do
             config.send(:set_path_variable, "var", nil, "ending", false)
-            config.instance_variable_defined?(:@var).should be_false
+            expect(config.instance_variable_defined?(:@var)).to eq(false)
           end
         end
       end # context 'when no path is given'
@@ -291,10 +291,10 @@ module Backup
         config.instance_variables.each do |var|
           config.send(:remove_instance_variable, var)
         end
-        config.instance_variables.should be_empty
+        expect(config.instance_variables).to be_empty
 
         load File.expand_path("../../lib/backup/config.rb", __FILE__)
-        config.instance_variables.sort.map(&:to_sym).should == expected
+        expect(config.instance_variables.sort.map(&:to_sym)).to eq(expected)
       end
 
       context "when setting @user" do
@@ -303,7 +303,7 @@ module Backup
 
           it 'should set value for @user to ENV["USER"]' do
             config.send(:reset!)
-            config.user.should == "test"
+            expect(config.user).to eq("test")
           end
         end
 
@@ -312,7 +312,7 @@ module Backup
 
           it "should set value using the user login name" do
             config.send(:reset!)
-            config.user.should == Etc.getpwuid.name
+            expect(config.user).to eq(Etc.getpwuid.name)
           end
         end
       end # context 'when setting @user'
@@ -323,8 +323,9 @@ module Backup
 
           it 'should set value using ENV["HOME"]' do
             config.send(:reset!)
-            config.root_path.should ==
+            expect(config.root_path).to eq(
               File.join(File.expand_path("test/home/dir"), "Backup")
+            )
           end
         end
 
@@ -333,7 +334,7 @@ module Backup
 
           it "should set value using $PWD" do
             config.send(:reset!)
-            config.root_path.should == File.expand_path("Backup")
+            expect(config.root_path).to eq(File.expand_path("Backup"))
           end
         end
       end # context 'when setting @root_path'

--- a/spec/database/mysql_spec.rb
+++ b/spec/database/mysql_spec.rb
@@ -35,7 +35,7 @@ module Backup
         expect(db.prepare_options).to be_nil
         expect(db.sudo_user).to be_nil
         expect(db.backup_engine).to eq :mysqldump
-        expect(db.prepare_backup).to be_true
+        expect(db.prepare_backup).to eq(true)
       end
 
       it "configures the database" do
@@ -68,8 +68,8 @@ module Backup
         expect(db.prepare_options).to eq "my_prepare_options"
         expect(db.sudo_user).to eq "my_sudo_user"
         expect(db.backup_engine).to eq "my_backup_engine"
-        expect(db.verbose).to be_false
-        expect(db.prepare_backup).to be_false
+        expect(db.verbose).to be_falsy
+        expect(db.prepare_backup).to eq(false)
       end
     end # describe '#initialize'
 

--- a/spec/database/openldap_spec.rb
+++ b/spec/database/openldap_spec.rb
@@ -22,7 +22,7 @@ module Backup
       it "provides default values" do
         expect(db.name).to eq("ldap_backup")
         expect(db.slapcat_args).to be_empty
-        expect(db.use_sudo).to be_false
+        expect(db.use_sudo).to eq(false)
         expect(db.slapcat_utility).to eq "/real/slapcat"
         expect(db.slapcat_conf).to eq "/etc/ldap/slapd.d"
       end

--- a/spec/database/sqlite_spec.rb
+++ b/spec/database/sqlite_spec.rb
@@ -26,13 +26,13 @@ module Backup
       end
 
       it "should pass the model reference to Base" do
-        db.instance_variable_get(:@model).should == model
+        expect(db.instance_variable_get(:@model)).to eq(model)
       end
 
       context "when no pre-configured defaults have been set" do
         context "when options are specified" do
           it "should use the given values" do
-            db.sqlitedump_utility.should == "/path/to/sqlitedump"
+            expect(db.sqlitedump_utility).to eq("/path/to/sqlitedump")
           end
         end
       end # context 'when no pre-configured defaults have been set'
@@ -48,7 +48,7 @@ module Backup
 
         context "when options are specified" do
           it "should override the pre-configured defaults" do
-            db.sqlitedump_utility.should == "/path/to/sqlitedump"
+            expect(db.sqlitedump_utility).to eq("/path/to/sqlitedump")
           end
         end
 
@@ -56,7 +56,7 @@ module Backup
           it "should use the pre-configured defaults" do
             db = Database::SQLite.new(model)
 
-            db.sqlitedump_utility.should == "/default/path/to/sqlitedump"
+            expect(db.sqlitedump_utility).to eq("/default/path/to/sqlitedump")
           end
         end
       end # context 'when no pre-configured defaults have been set'

--- a/spec/encryptor/base_spec.rb
+++ b/spec/encryptor/base_spec.rb
@@ -4,13 +4,13 @@ describe Backup::Encryptor::Base do
   let(:base) { Backup::Encryptor::Base.new }
 
   it "should include Utilities::Helpers" do
-    Backup::Encryptor::Base
-      .include?(Backup::Utilities::Helpers).should be_true
+    expect(Backup::Encryptor::Base
+      .include?(Backup::Utilities::Helpers)).to eq(true)
   end
 
   it "should include Config::Helpers" do
-    Backup::Encryptor::Base
-      .include?(Backup::Config::Helpers).should be_true
+    expect(Backup::Encryptor::Base
+      .include?(Backup::Config::Helpers)).to eq(true)
   end
 
   describe "#initialize" do
@@ -22,7 +22,7 @@ describe Backup::Encryptor::Base do
 
   describe "#encryptor_name" do
     it "should return class name with Backup namespace removed" do
-      base.send(:encryptor_name).should == "Encryptor::Base"
+      expect(base.send(:encryptor_name)).to eq("Encryptor::Base")
     end
   end
 

--- a/spec/encryptor/gpg_spec.rb
+++ b/spec/encryptor/gpg_spec.rb
@@ -9,25 +9,25 @@ describe Backup::Encryptor::GPG do
   end
 
   it "should be a subclass of Encryptor::Base" do
-    Backup::Encryptor::GPG
-      .superclass.should == Backup::Encryptor::Base
+    expect(Backup::Encryptor::GPG
+      .superclass).to eq(Backup::Encryptor::Base)
   end
 
   it "supports three modes of operation" do
-    Backup::Encryptor::GPG::MODES.should == [:asymmetric, :symmetric, :both]
+    expect(Backup::Encryptor::GPG::MODES).to eq([:asymmetric, :symmetric, :both])
   end
 
   describe "#mode=" do
     it "should accept valid modes" do
       mode = Backup::Encryptor::GPG::MODES.sample
       encryptor.mode = mode
-      encryptor.mode.should == mode
+      expect(encryptor.mode).to eq(mode)
     end
 
     it "should convert string input to a symbol" do
       mode = Backup::Encryptor::GPG::MODES.sample
       encryptor.mode = mode.to_s
-      encryptor.mode.should == mode
+      expect(encryptor.mode).to eq(mode)
     end
 
     it "should raise an error for invalid modes" do
@@ -47,19 +47,19 @@ describe Backup::Encryptor::GPG do
 
     context "when no pre-configured defaults have been set" do
       it "should use the values given" do
-        encryptor.mode.should == :symmetric
-        encryptor.passphrase.should == "test secret"
+        expect(encryptor.mode).to eq(:symmetric)
+        expect(encryptor.passphrase).to eq("test secret")
       end
 
       it "should use default values if none are given" do
         encryptor = Backup::Encryptor::GPG.new
-        encryptor.mode.should == :asymmetric
-        encryptor.keys.should be_nil
-        encryptor.recipients.should be_nil
-        encryptor.passphrase.should be_nil
-        encryptor.passphrase_file.should be_nil
-        encryptor.gpg_config.should be_nil
-        encryptor.gpg_homedir.should be_nil
+        expect(encryptor.mode).to eq(:asymmetric)
+        expect(encryptor.keys).to be_nil
+        expect(encryptor.recipients).to be_nil
+        expect(encryptor.passphrase).to be_nil
+        expect(encryptor.passphrase_file).to be_nil
+        expect(encryptor.gpg_config).to be_nil
+        expect(encryptor.gpg_homedir).to be_nil
       end
     end # context 'when no pre-configured defaults have been set'
 
@@ -75,18 +75,18 @@ describe Backup::Encryptor::GPG do
 
       it "should use pre-configured defaults" do
         encryptor = Backup::Encryptor::GPG.new
-        encryptor.mode.should == :both
-        encryptor.keys.should == { "test_key" => "test public key" }
-        encryptor.recipients.should == "test_key"
-        encryptor.passphrase_file.should == "my/pass/file"
+        expect(encryptor.mode).to eq(:both)
+        expect(encryptor.keys).to eq({ "test_key" => "test public key" })
+        expect(encryptor.recipients).to eq("test_key")
+        expect(encryptor.passphrase_file).to eq("my/pass/file")
       end
 
       it "should override pre-configured defaults" do
-        encryptor.mode.should == :symmetric
-        encryptor.keys.should == { "test_key" => "test public key" }
-        encryptor.recipients.should == "test_key"
-        encryptor.passphrase.should == "test secret"
-        encryptor.passphrase_file.should == "my/pass/file"
+        expect(encryptor.mode).to eq(:symmetric)
+        expect(encryptor.keys).to eq({ "test_key" => "test public key" })
+        expect(encryptor.recipients).to eq("test_key")
+        expect(encryptor.passphrase).to eq("test secret")
+        expect(encryptor.passphrase_file).to eq("my/pass/file")
       end
     end # context 'when pre-configured defaults have been set'
   end # describe '#initialize'
@@ -105,8 +105,8 @@ describe Backup::Encryptor::GPG do
         encryptor.expects(:utility).with(:gpg).returns("gpg")
 
         encryptor.encrypt_with do |command, ext|
-          command.should == "gpg base_options mode_options"
-          ext.should == ".gpg"
+          expect(command).to eq("gpg base_options mode_options")
+          expect(ext).to eq(".gpg")
         end
       end
     end
@@ -127,7 +127,7 @@ describe Backup::Encryptor::GPG do
       encryptor.instance_variable_set(:@tempdirs, nil)
       FileUtils.expects(:rm_rf).never
       encryptor.send(:prepare)
-      encryptor.instance_variable_get(:@tempdirs).should == []
+      expect(encryptor.instance_variable_get(:@tempdirs)).to eq([])
     end
 
     it "should remove any tempdirs and clear all variables" do
@@ -142,12 +142,12 @@ describe Backup::Encryptor::GPG do
 
       encryptor.send(:cleanup)
 
-      encryptor.instance_variable_get(:@tempdirs).should == []
-      encryptor.instance_variable_get(:@base_options).should be_nil
-      encryptor.instance_variable_get(:@mode_options).should be_nil
-      encryptor.instance_variable_get(:@user_recipients).should be_nil
-      encryptor.instance_variable_get(:@user_keys).should be_nil
-      encryptor.instance_variable_get(:@system_identifiers).should be_nil
+      expect(encryptor.instance_variable_get(:@tempdirs)).to eq([])
+      expect(encryptor.instance_variable_get(:@base_options)).to be_nil
+      expect(encryptor.instance_variable_get(:@mode_options)).to be_nil
+      expect(encryptor.instance_variable_get(:@user_recipients)).to be_nil
+      expect(encryptor.instance_variable_get(:@user_keys)).to be_nil
+      expect(encryptor.instance_variable_get(:@system_identifiers)).to be_nil
     end
   end # describe '#prepare and #cleanup'
 
@@ -161,9 +161,9 @@ describe Backup::Encryptor::GPG do
           encryptor.expects(:setup_gpg_config).once.returns(false)
 
           ret = "--no-tty --homedir '/a/dir'"
-          encryptor.send(:base_options).should == ret
-          encryptor.send(:base_options).should == ret
-          encryptor.instance_variable_get(:@base_options).should == ret
+          expect(encryptor.send(:base_options)).to eq(ret)
+          expect(encryptor.send(:base_options)).to eq(ret)
+          expect(encryptor.instance_variable_get(:@base_options)).to eq(ret)
         end
       end
 
@@ -173,9 +173,9 @@ describe Backup::Encryptor::GPG do
           encryptor.expects(:setup_gpg_config).once.returns("/a/file")
 
           ret = "--no-tty --options '/a/file'"
-          encryptor.send(:base_options).should == ret
-          encryptor.send(:base_options).should == ret
-          encryptor.instance_variable_get(:@base_options).should == ret
+          expect(encryptor.send(:base_options)).to eq(ret)
+          expect(encryptor.send(:base_options)).to eq(ret)
+          expect(encryptor.instance_variable_get(:@base_options)).to eq(ret)
         end
       end
 
@@ -185,9 +185,9 @@ describe Backup::Encryptor::GPG do
           encryptor.expects(:setup_gpg_config).once.returns("/a/file")
 
           ret = "--no-tty --homedir '/a/dir' --options '/a/file'"
-          encryptor.send(:base_options).should == ret
-          encryptor.send(:base_options).should == ret
-          encryptor.instance_variable_get(:@base_options).should == ret
+          expect(encryptor.send(:base_options)).to eq(ret)
+          expect(encryptor.send(:base_options)).to eq(ret)
+          expect(encryptor.instance_variable_get(:@base_options)).to eq(ret)
         end
       end
 
@@ -197,9 +197,9 @@ describe Backup::Encryptor::GPG do
           encryptor.expects(:setup_gpg_config).once.returns(false)
 
           ret = "--no-tty"
-          encryptor.send(:base_options).should == ret
-          encryptor.send(:base_options).should == ret
-          encryptor.instance_variable_get(:@base_options).should == ret
+          expect(encryptor.send(:base_options)).to eq(ret)
+          expect(encryptor.send(:base_options)).to eq(ret)
+          expect(encryptor.instance_variable_get(:@base_options)).to eq(ret)
         end
       end
     end
@@ -209,7 +209,7 @@ describe Backup::Encryptor::GPG do
     context "when #gpg_homedir is not set" do
       it "should return false" do
         encryptor.gpg_homedir = nil
-        encryptor.send(:setup_gpg_homedir).should be_false
+        expect(encryptor.send(:setup_gpg_homedir)).to eq(false)
       end
     end
 
@@ -240,7 +240,7 @@ describe Backup::Encryptor::GPG do
 
           it "should ensure permissions and return the path" do
             encryptor.expects(:utility).never
-            encryptor.send(:setup_gpg_homedir).should == expanded_path
+            expect(encryptor.send(:setup_gpg_homedir)).to eq(expanded_path)
           end
         end
 
@@ -254,7 +254,7 @@ describe Backup::Encryptor::GPG do
             encryptor.expects(:run).with(
               "gpg --homedir '#{expanded_path}' -K 2>&1 >/dev/null"
             )
-            encryptor.send(:setup_gpg_homedir).should == expanded_path
+            expect(encryptor.send(:setup_gpg_homedir)).to eq(expanded_path)
           end
         end
       end
@@ -266,10 +266,9 @@ describe Backup::Encryptor::GPG do
           expect do
             encryptor.send(:setup_gpg_homedir)
           end.to raise_error { |err|
-            err.should
-            be_an_instance_of Backup::Encryptor::GPG::Error
-            err.message.should match("Failed to create or set permissions")
-            err.message.should match("RuntimeError: error message")
+            expect(err).to be_an_instance_of Backup::Encryptor::GPG::Error
+            expect(err.message).to match("Failed to create or set permissions")
+            expect(err.message).to match("RuntimeError: error message")
           }
         end
       end
@@ -280,7 +279,7 @@ describe Backup::Encryptor::GPG do
     context "when #gpg_config is not set" do
       it "should return false" do
         encryptor.gpg_config = nil
-        encryptor.send(:setup_gpg_config).should be_false
+        expect(encryptor.send(:setup_gpg_config)).to eq(false)
       end
     end
 
@@ -300,7 +299,7 @@ describe Backup::Encryptor::GPG do
         let(:tempdir) { mock }
         let(:tempfile) { mock }
         let(:tempfile_path) { mock }
-        let(:path) { mock }
+        let(:path) { double }
 
         before do
           encryptor.expects(:cleanup).never
@@ -332,10 +331,10 @@ describe Backup::Encryptor::GPG do
           encryptor.expects(:check_gpg_config).with(tempfile_path)
 
           # method returns the tempfile's path
-          encryptor.send(:setup_gpg_config).should == tempfile_path
+          expect(encryptor.send(:setup_gpg_config)).to eq(tempfile_path)
 
           # tempdir added to @tempdirs
-          encryptor.instance_variable_get(:@tempdirs)[0].should == tempdir
+          expect(encryptor.instance_variable_get(:@tempdirs)[0]).to eq(tempdir)
         end
       end
 
@@ -350,9 +349,9 @@ describe Backup::Encryptor::GPG do
           expect do
             encryptor.send(:setup_gpg_config)
           end.to raise_error { |err|
-            err.should be_an_instance_of(Backup::Encryptor::GPG::Error)
-            err.message.should match("Error creating temporary file for #gpg_config")
-            err.message.should match("RuntimeError: an error")
+            expect(err).to be_an_instance_of(Backup::Encryptor::GPG::Error)
+            expect(err.message).to match("Error creating temporary file for #gpg_config")
+            expect(err.message).to match("RuntimeError: an error")
           }
         end
       end
@@ -374,7 +373,7 @@ describe Backup::Encryptor::GPG do
       before { cmd_ret.expects(:chomp).returns("") }
 
       it "should do nothing" do
-        encryptor.send(:check_gpg_config, file_path).should be_nil
+        expect(encryptor.send(:check_gpg_config, file_path)).to be_nil
       end
     end
 
@@ -403,9 +402,9 @@ describe Backup::Encryptor::GPG do
           encryptor.expects(:asymmetric_options).never
 
           encryptor.mode = :symmetric
-          encryptor.send(:mode_options).should == s_opts
-          encryptor.send(:mode_options).should == s_opts
-          encryptor.instance_variable_get(:@mode_options).should == s_opts
+          expect(encryptor.send(:mode_options)).to eq(s_opts)
+          expect(encryptor.send(:mode_options)).to eq(s_opts)
+          expect(encryptor.instance_variable_get(:@mode_options)).to eq(s_opts)
         end
       end
 
@@ -415,9 +414,9 @@ describe Backup::Encryptor::GPG do
           encryptor.expects(:asymmetric_options).once.returns(a_opts)
 
           encryptor.mode = :asymmetric
-          encryptor.send(:mode_options).should == a_opts
-          encryptor.send(:mode_options).should == a_opts
-          encryptor.instance_variable_get(:@mode_options).should == a_opts
+          expect(encryptor.send(:mode_options)).to eq(a_opts)
+          expect(encryptor.send(:mode_options)).to eq(a_opts)
+          expect(encryptor.instance_variable_get(:@mode_options)).to eq(a_opts)
         end
       end
 
@@ -429,9 +428,9 @@ describe Backup::Encryptor::GPG do
           encryptor.mode = :both
           opts = "#{s_opts} #{a_opts}"
 
-          encryptor.send(:mode_options).should == opts
-          encryptor.send(:mode_options).should == opts
-          encryptor.instance_variable_get(:@mode_options).should == opts
+          expect(encryptor.send(:mode_options)).to eq(opts)
+          expect(encryptor.send(:mode_options)).to eq(opts)
+          expect(encryptor.instance_variable_get(:@mode_options)).to eq(opts)
         end
       end
     end
@@ -446,7 +445,7 @@ describe Backup::Encryptor::GPG do
         encryptor.expects(:setup_passphrase_file).returns(path)
         File.expects(:exist?).with(path).returns(true)
 
-        encryptor.send(:symmetric_options).should == s_opts
+        expect(encryptor.send(:symmetric_options)).to eq(s_opts)
       end
     end
 
@@ -460,7 +459,7 @@ describe Backup::Encryptor::GPG do
           encryptor.expects(:passphrase_file).returns(nil)
           Backup::Logger.expects(:warn)
 
-          encryptor.send(:symmetric_options).should be_nil
+          expect(encryptor.send(:symmetric_options)).to be_nil
         end
       end
 
@@ -473,7 +472,7 @@ describe Backup::Encryptor::GPG do
         context "when :passphrase_file exists" do
           it "should return the options" do
             File.expects(:exist?).with(path).returns(true)
-            encryptor.send(:symmetric_options).should == s_opts
+            expect(encryptor.send(:symmetric_options)).to eq(s_opts)
           end
         end
 
@@ -481,7 +480,7 @@ describe Backup::Encryptor::GPG do
           it "should return nil and log a warning" do
             File.expects(:exist?).with(path).returns(false)
             Backup::Logger.expects(:warn)
-            encryptor.send(:symmetric_options).should be_nil
+            expect(encryptor.send(:symmetric_options)).to be_nil
           end
         end
       end
@@ -492,7 +491,7 @@ describe Backup::Encryptor::GPG do
     context "when :passphrase is not set" do
       it "should return false" do
         encryptor.expects(:passphrase).returns(nil)
-        encryptor.send(:setup_passphrase_file).should be_false
+        expect(encryptor.send(:setup_passphrase_file)).to eq(false)
       end
     end
 
@@ -522,10 +521,10 @@ describe Backup::Encryptor::GPG do
           tempfile.expects(:write).with("a secret")
           tempfile.expects(:close)
 
-          encryptor.send(:setup_passphrase_file).should == tempfile_path
+          expect(encryptor.send(:setup_passphrase_file)).to eq(tempfile_path)
 
           # adds the temporary directory to @tempdirs
-          encryptor.instance_variable_get(:@tempdirs)[0].should == tempdir
+          expect(encryptor.instance_variable_get(:@tempdirs)[0]).to eq(tempdir)
         end
       end
 
@@ -533,11 +532,11 @@ describe Backup::Encryptor::GPG do
         it "should return false and log a warning" do
           Dir.expects(:mktmpdir).raises("an error")
           Backup::Logger.expects(:warn).with do |err|
-            err.should be_an_instance_of(Backup::Encryptor::GPG::Error)
-            err.message.should match("Error creating temporary passphrase file")
-            err.message.should match("RuntimeError: an error")
+            expect(err).to be_an_instance_of(Backup::Encryptor::GPG::Error)
+            expect(err.message).to match("Error creating temporary passphrase file")
+            expect(err.message).to match("RuntimeError: an error")
           end
-          encryptor.send(:setup_passphrase_file).should be_false
+          expect(encryptor.send(:setup_passphrase_file)).to eq(false)
         end
       end
     end
@@ -547,8 +546,9 @@ describe Backup::Encryptor::GPG do
     context "when recipients are found" do
       it "should return the options" do
         encryptor.stubs(:user_recipients).returns(["keyid1", "keyid2"])
-        encryptor.send(:asymmetric_options).should ==
+        expect(encryptor.send(:asymmetric_options)).to eq(
           "-e --trust-model always -r 'keyid1' -r 'keyid2'"
+        )
       end
     end
 
@@ -556,7 +556,7 @@ describe Backup::Encryptor::GPG do
       it "should return nil log a warning" do
         encryptor.expects(:user_recipients).returns([])
         Backup::Logger.expects(:warn)
-        encryptor.send(:asymmetric_options).should be_nil
+        expect(encryptor.send(:asymmetric_options)).to be_nil
       end
     end
   end # describe '#asymmetric_options'
@@ -584,15 +584,15 @@ describe Backup::Encryptor::GPG do
         # key_id4 will not be found in user_keys, so a warning will be logged.
         # This will return nil into the array, which will be compacted out.
         Backup::Logger.expects(:warn).with do |msg|
-          msg.should match(/'key_id4'/)
+          expect(msg).to match(/'key_id4'/)
         end
 
         encryptor.instance_variable_set(:@user_recipients, nil)
         recipient_list = ["key_id1", "key_id2", "key_id3"]
-        encryptor.send(:user_recipients).should == recipient_list
+        expect(encryptor.send(:user_recipients)).to eq(recipient_list)
         # results are cached (expectations would fail if called twice)
-        encryptor.send(:user_recipients).should == recipient_list
-        encryptor.instance_variable_get(:@user_recipients).should == recipient_list
+        expect(encryptor.send(:user_recipients)).to eq(recipient_list)
+        expect(encryptor.instance_variable_get(:@user_recipients)).to eq(recipient_list)
       end
     end
 
@@ -603,14 +603,14 @@ describe Backup::Encryptor::GPG do
         encryptor.stubs(:system_identifiers).returns(["key_id"])
         encryptor.expects(:clean_identifier).with("key_id").returns("key_id")
 
-        encryptor.send(:user_recipients).should == ["key_id"]
+        expect(encryptor.send(:user_recipients)).to eq(["key_id"])
       end
     end
 
     context "when :recipients is not set" do
       it "should return an empty Array" do
         encryptor.expects(:recipients).returns(nil)
-        encryptor.send(:user_recipients).should == []
+        expect(encryptor.send(:user_recipients)).to eq([])
       end
     end
   end # describe '#user_recipients'
@@ -634,10 +634,10 @@ describe Backup::Encryptor::GPG do
         cleaned_hash = {
           "clean_key1" => :foo, "clean_key2" => :foo, "clean_key3" => :foo
         }
-        encryptor.send(:user_keys).should == cleaned_hash
+        expect(encryptor.send(:user_keys)).to eq(cleaned_hash)
         # results are cached (expectations would fail if called twice)
-        encryptor.send(:user_keys).should == cleaned_hash
-        encryptor.instance_variable_get(:@user_keys).should == cleaned_hash
+        expect(encryptor.send(:user_keys)).to eq(cleaned_hash)
+        expect(encryptor.instance_variable_get(:@user_keys)).to eq(cleaned_hash)
       end
 
       it "should log a warning if cleaning results in a duplicate identifier" do
@@ -651,10 +651,10 @@ describe Backup::Encryptor::GPG do
         cleaned_hash = {
           "clean_key1" => :foo, "clean_key2" => :foo
         }
-        encryptor.send(:user_keys).should == cleaned_hash
+        expect(encryptor.send(:user_keys)).to eq(cleaned_hash)
         # results are cached (expectations would fail if called twice)
-        encryptor.send(:user_keys).should == cleaned_hash
-        encryptor.instance_variable_get(:@user_keys).should == cleaned_hash
+        expect(encryptor.send(:user_keys)).to eq(cleaned_hash)
+        expect(encryptor.instance_variable_get(:@user_keys)).to eq(cleaned_hash)
       end
     end
 
@@ -665,15 +665,15 @@ describe Backup::Encryptor::GPG do
       end
 
       it "should return an empty hash" do
-        encryptor.send(:user_keys).should == {}
+        expect(encryptor.send(:user_keys)).to eq({})
       end
     end
   end # describe '#user_keys'
 
   describe "#clean_identifier" do
     it "should remove all spaces and upcase non-email identifiers" do
-      encryptor.send(:clean_identifier, " 9d66 6290 c5f7 ee0f ")
-        .should == "9D666290C5F7EE0F"
+      expect(encryptor.send(:clean_identifier, " 9d66 6290 c5f7 ee0f "))
+        .to eq("9D666290C5F7EE0F")
     end
 
     # Even though spaces in an email are technically possible,
@@ -690,9 +690,9 @@ describe Backup::Encryptor::GPG do
         "<Foo_Bar@example.com>"
       ]
 
-      emails.map do |email|
+      expect(emails.map do |email|
         encryptor.send(:clean_identifier, email)
-      end.should == cleaned
+      end).to eq(cleaned)
     end
   end # describe '#clean_identifier'
 
@@ -761,8 +761,8 @@ gXY+pNqaEE6cHrg+uQatVQITX8EoVJhQ9Z1mYJB+g62zqOQPe10Spb381O9y4dN/
 
         Backup::Logger.expects(:warn).never
 
-        encryptor.send(:import_key, "some_identifier", gpg_key)
-          .should == "9D666290C5F7EE0F"
+        expect(encryptor.send(:import_key, "some_identifier", gpg_key))
+          .to eq("9D666290C5F7EE0F")
       end
     end
 
@@ -770,12 +770,12 @@ gXY+pNqaEE6cHrg+uQatVQITX8EoVJhQ9Z1mYJB+g62zqOQPe10Spb381O9y4dN/
       it "should return nil and log a warning" do
         Tempfile.expects(:open).raises("an error")
         Backup::Logger.expects(:warn).with do |err|
-          err.should be_an_instance_of(Backup::Encryptor::GPG::Error)
-          err.message.should match("Public key import failed for 'some_identifier'")
-          err.message.should match("RuntimeError: an error")
+          expect(err).to be_an_instance_of(Backup::Encryptor::GPG::Error)
+          expect(err.message).to match("Public key import failed for 'some_identifier'")
+          expect(err.message).to match("RuntimeError: an error")
         end
 
-        encryptor.send(:import_key, "some_identifier", "foo").should be_nil
+        expect(encryptor.send(:import_key, "some_identifier", "foo")).to be_nil
       end
     end
   end # describe '#import_key'
@@ -858,11 +858,11 @@ gXY+pNqaEE6cHrg+uQatVQITX8EoVJhQ9Z1mYJB+g62zqOQPe10Spb381O9y4dN/
         "gpg --base 'options' --with-colons --fixed-list-mode --fingerprint"
       ).returns(gpg_output)
 
-      encryptor.send(:system_identifiers).should == valid_identifiers
+      expect(encryptor.send(:system_identifiers)).to eq(valid_identifiers)
       # results cached
-      encryptor.send(:system_identifiers).should == valid_identifiers
-      encryptor.instance_variable_get(:@system_identifiers)
-        .should == valid_identifiers
+      expect(encryptor.send(:system_identifiers)).to eq(valid_identifiers)
+      expect(encryptor.instance_variable_get(:@system_identifiers))
+        .to eq(valid_identifiers)
     end
   end # describe '#system_identifiers'
 end

--- a/spec/encryptor/gpg_spec.rb
+++ b/spec/encryptor/gpg_spec.rb
@@ -76,14 +76,14 @@ describe Backup::Encryptor::GPG do
       it "should use pre-configured defaults" do
         encryptor = Backup::Encryptor::GPG.new
         expect(encryptor.mode).to eq(:both)
-        expect(encryptor.keys).to eq({ "test_key" => "test public key" })
+        expect(encryptor.keys).to eq("test_key" => "test public key")
         expect(encryptor.recipients).to eq("test_key")
         expect(encryptor.passphrase_file).to eq("my/pass/file")
       end
 
       it "should override pre-configured defaults" do
         expect(encryptor.mode).to eq(:symmetric)
-        expect(encryptor.keys).to eq({ "test_key" => "test public key" })
+        expect(encryptor.keys).to eq("test_key" => "test public key")
         expect(encryptor.recipients).to eq("test_key")
         expect(encryptor.passphrase).to eq("test secret")
         expect(encryptor.passphrase_file).to eq("my/pass/file")

--- a/spec/encryptor/open_ssl_spec.rb
+++ b/spec/encryptor/open_ssl_spec.rb
@@ -11,8 +11,8 @@ describe Backup::Encryptor::OpenSSL do
   end
 
   it "should be a subclass of Encryptor::Base" do
-    Backup::Encryptor::OpenSSL
-      .superclass.should == Backup::Encryptor::Base
+    expect(Backup::Encryptor::OpenSSL
+      .superclass).to eq(Backup::Encryptor::Base)
   end
 
   describe "#initialize" do
@@ -25,18 +25,18 @@ describe Backup::Encryptor::OpenSSL do
 
     context "when no pre-configured defaults have been set" do
       it "should use the values given" do
-        encryptor.password.should       == "mypassword"
-        encryptor.password_file.should  == "/my/password/file"
-        encryptor.base64.should         == true
-        encryptor.salt.should           == true
+        expect(encryptor.password).to       eq("mypassword")
+        expect(encryptor.password_file).to  eq("/my/password/file")
+        expect(encryptor.base64).to         eq(true)
+        expect(encryptor.salt).to           eq(true)
       end
 
       it "should use default values if none are given" do
         encryptor = Backup::Encryptor::OpenSSL.new
-        encryptor.password.should       be_nil
-        encryptor.password_file.should  be_nil
-        encryptor.base64.should         be_false
-        encryptor.salt.should           be_true
+        expect(encryptor.password).to       be_nil
+        expect(encryptor.password_file).to  be_nil
+        expect(encryptor.base64).to         eq(false)
+        expect(encryptor.salt).to           eq(true)
       end
     end # context 'when no pre-configured defaults have been set'
 
@@ -59,10 +59,10 @@ describe Backup::Encryptor::OpenSSL do
       end
 
       it "should override pre-configured defaults" do
-        encryptor.password.should       == "mypassword"
-        encryptor.password_file.should  == "/my/password/file"
-        encryptor.base64.should         == true
-        encryptor.salt.should           == true
+        expect(encryptor.password).to       eq("mypassword")
+        expect(encryptor.password_file).to  eq("/my/password/file")
+        expect(encryptor.base64).to         eq(true)
+        expect(encryptor.salt).to           eq(true)
       end
     end # context 'when pre-configured defaults have been set'
   end # describe '#initialize'
@@ -74,8 +74,8 @@ describe Backup::Encryptor::OpenSSL do
       encryptor.expects(:options).returns("cmd_options")
 
       encryptor.encrypt_with do |command, ext|
-        command.should == "openssl_cmd cmd_options"
-        ext.should == ".enc"
+        expect(command).to eq("openssl_cmd cmd_options")
+        expect(ext).to eq(".enc")
       end
     end
   end
@@ -90,12 +90,13 @@ describe Backup::Encryptor::OpenSSL do
 
     context "with no options given" do
       it "should always include cipher command" do
-        encryptor.send(:options).should match(/^aes-256-cbc\s.*$/)
+        expect(encryptor.send(:options)).to match(/^aes-256-cbc\s.*$/)
       end
 
       it "should add #password option whenever #password_file not given" do
-        encryptor.send(:options).should ==
+        expect(encryptor.send(:options)).to eq(
           "aes-256-cbc -k ''"
+        )
       end
     end
 
@@ -103,14 +104,16 @@ describe Backup::Encryptor::OpenSSL do
       before { encryptor.password_file = "password_file" }
 
       it "should add #password_file option" do
-        encryptor.send(:options).should ==
+        expect(encryptor.send(:options)).to eq(
           "aes-256-cbc -pass file:password_file"
+        )
       end
 
       it "should add #password_file option even when #password given" do
         encryptor.password = "password"
-        encryptor.send(:options).should ==
+        expect(encryptor.send(:options)).to eq(
           "aes-256-cbc -pass file:password_file"
+        )
       end
     end
 
@@ -118,8 +121,9 @@ describe Backup::Encryptor::OpenSSL do
       before { encryptor.password = %q(pa\ss'w"ord) }
 
       it "should include the given password in the #password option" do
-        encryptor.send(:options).should ==
+        expect(encryptor.send(:options)).to eq(
           %q(aes-256-cbc -k pa\\\ss\'w\"ord)
+        )
       end
     end
 
@@ -127,8 +131,9 @@ describe Backup::Encryptor::OpenSSL do
       before { encryptor.base64 = true }
 
       it "should add the option" do
-        encryptor.send(:options).should ==
+        expect(encryptor.send(:options)).to eq(
           "aes-256-cbc -base64 -k ''"
+        )
       end
     end
 
@@ -136,8 +141,9 @@ describe Backup::Encryptor::OpenSSL do
       before { encryptor.salt = true }
 
       it "should add the option" do
-        encryptor.send(:options).should ==
+        expect(encryptor.send(:options)).to eq(
           "aes-256-cbc -salt -k ''"
+        )
       end
     end
   end # describe '#options'

--- a/spec/logger/logfile_spec.rb
+++ b/spec/logger/logfile_spec.rb
@@ -37,7 +37,7 @@ module Backup
 
         Logger::Syslog.any_instance.expects(:log).never
         Logger.info "message"
-        File.exist?(@log_path_default).should be_false
+        expect(File.exist?(@log_path_default)).to eq(false)
       end
 
       it "may be forced disabled via the command line" do
@@ -53,7 +53,7 @@ module Backup
 
         Logger::Syslog.any_instance.expects(:log).never
         Logger.info "message"
-        File.exist?(@log_path_default).should be_false
+        expect(File.exist?(@log_path_default)).to eq(false)
       end
 
       it "ignores log_path setting if it is already set" do
@@ -68,9 +68,9 @@ module Backup
 
         Logger.start!
 
-        File.exist?(@log_path_default).should be_false
-        File.exist?(@log_path_absolute).should be_false
-        File.exist?(@log_path_rel).should be_true
+        expect(File.exist?(@log_path_default)).to eq(false)
+        expect(File.exist?(@log_path_absolute)).to eq(false)
+        expect(File.exist?(@log_path_rel)).to eq(true)
       end
     end
 
@@ -82,9 +82,9 @@ module Backup
           end
 
           it "should create the default log_path" do
-            File.exist?(@log_path_rel).should be_false
-            File.exist?(@log_path_absolute).should be_false
-            File.exist?(@log_path_default).should be_true
+            expect(File.exist?(@log_path_rel)).to eq(false)
+            expect(File.exist?(@log_path_absolute)).to eq(false)
+            expect(File.exist?(@log_path_default)).to eq(true)
           end
         end
 
@@ -98,9 +98,9 @@ module Backup
           end
 
           it "should create the absolute log_path" do
-            File.exist?(@log_path_default).should be_false
-            File.exist?(@log_path_rel).should be_false
-            File.exist?(@log_path_absolute).should be_true
+            expect(File.exist?(@log_path_default)).to eq(false)
+            expect(File.exist?(@log_path_rel)).to eq(false)
+            expect(File.exist?(@log_path_absolute)).to eq(true)
           end
         end
 
@@ -113,9 +113,9 @@ module Backup
           end
 
           it "should create the log_path relative to Backup::Config.root_path" do
-            File.exist?(@log_path_default).should be_false
-            File.exist?(@log_path_absolute).should be_false
-            File.exist?(@log_path_rel).should be_true
+            expect(File.exist?(@log_path_default)).to eq(false)
+            expect(File.exist?(@log_path_absolute)).to eq(false)
+            expect(File.exist?(@log_path_rel)).to eq(true)
           end
         end
       end # describe 'log_path creation'
@@ -140,12 +140,12 @@ module Backup
                 bytes += file.write((lineno += 1).to_s.ljust(120, "x") + "\n")
               end
             end
-            File.stat(@logfile_default).size.should be >= 1200
+            expect(File.stat(@logfile_default).size).to be >= 1200
 
             Logger.start!
-            File.stat(@logfile_default).size.should be <= 1000
-            File.readlines(@logfile_default).last.should match(/#{ lineno }x/)
-            File.exist?(@logfile_default + "~").should be_false
+            expect(File.stat(@logfile_default).size).to be <= 1000
+            expect(File.readlines(@logfile_default).last).to match(/#{ lineno }x/)
+            expect(File.exist?(@logfile_default + "~")).to eq(false)
           end
         end
 
@@ -155,10 +155,10 @@ module Backup
             Logger.start!
             Logger.info "a message"
 
-            File.stat(@logfile_default).size.should be > 0
-            File.stat(@logfile_default).size.should be < 500
-            File.exist?(@log_path_default).should be_true
-            File.exist?(@logfile_default).should be_true
+            expect(File.stat(@logfile_default).size).to be > 0
+            expect(File.stat(@logfile_default).size).to be < 500
+            expect(File.exist?(@log_path_default)).to eq(true)
+            expect(File.exist?(@logfile_default)).to eq(true)
           end
         end
 
@@ -166,8 +166,8 @@ module Backup
           it "does not truncates the file" do
             File.expects(:mv).never
             Logger.start!
-            File.exist?(@log_path_default).should be_true
-            File.exist?(@logfile_default).should be_false
+            expect(File.exist?(@log_path_default)).to eq(true)
+            expect(File.exist?(@logfile_default)).to eq(false)
           end
         end
       end # describe 'logfile truncation'
@@ -183,21 +183,21 @@ module Backup
       it "writes formatted messages to the log file" do
         Timecop.freeze do
           Logger.info "line one\nline two"
-          File.readlines(@logfile_default).should == [
+          expect(File.readlines(@logfile_default)).to eq([
             "[#{timestamp}][info] line one\n",
             "[#{timestamp}][info] line two\n"
-          ]
+          ])
         end
       end
 
       it "preserves blank lines within the messages" do
         Timecop.freeze do
           Logger.info "line one\n\nline two"
-          File.readlines(@logfile_default).should == [
+          expect(File.readlines(@logfile_default)).to eq([
             "[#{timestamp}][info] line one\n",
             "[#{timestamp}][info] \n",
             "[#{timestamp}][info] line two\n"
-          ]
+          ])
         end
       end
     end # describe '#log'

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -25,9 +25,9 @@ module Backup
         it "returns a new message object" do
           Timecop.freeze do
             msg = Logger::Message.new(Time.now, :log_level, ["message", "lines"])
-            msg.time.should == Time.now
-            msg.level.should == :log_level
-            msg.lines.should == ["message", "lines"]
+            expect(msg.time).to eq(Time.now)
+            expect(msg.level).to eq(:log_level)
+            expect(msg.lines).to eq(["message", "lines"])
           end
         end
       end
@@ -37,10 +37,10 @@ module Backup
           Timecop.freeze do
             timestamp = Time.now.strftime("%Y/%m/%d %H:%M:%S")
             msg = Logger::Message.new(Time.now, :log_level, ["message", "lines"])
-            msg.formatted_lines.should == [
+            expect(msg.formatted_lines).to eq([
               "[#{timestamp}][log_level] message",
               "[#{timestamp}][log_level] lines"
-            ]
+            ])
           end
         end
 
@@ -48,11 +48,11 @@ module Backup
           Timecop.freeze do
             timestamp = Time.now.strftime("%Y/%m/%d %H:%M:%S")
             msg = Logger::Message.new(Time.now, :log_level, ["message", "", "lines"])
-            msg.formatted_lines.should == [
+            expect(msg.formatted_lines).to eq([
               "[#{timestamp}][log_level] message",
               "[#{timestamp}][log_level] ",
               "[#{timestamp}][log_level] lines"
-            ]
+            ])
           end
         end
       end
@@ -92,11 +92,11 @@ module Backup
 
         it "sends messages to only the enabled loggers" do
           console_logger.expects(:log).with do |msg|
-            msg.lines.should == ["line 1", "line 2"]
+            expect(msg.lines).to eq(["line 1", "line 2"])
           end
 
           logfile_logger.expects(:log).with do |msg|
-            msg.lines.should == ["line 1", "line 2"]
+            expect(msg.lines).to eq(["line 1", "line 2"])
           end
 
           syslog_logger.expects(:log).never
@@ -120,11 +120,11 @@ module Backup
           console_logger.expects(:log).never
 
           logfile_logger.expects(:log).with do |msg|
-            msg.lines.should == ["line 1", "line 2"]
+            expect(msg.lines).to eq(["line 1", "line 2"])
           end
 
           syslog_logger.expects(:log).with do |msg|
-            msg.lines.should == ["line 1", "line 2"]
+            expect(msg.lines).to eq(["line 1", "line 2"])
           end
 
           Logger.start!
@@ -144,13 +144,13 @@ module Backup
 
         it "sends messages to only the enabled loggers" do
           console_logger.expects(:log).with do |msg|
-            msg.lines.should == ["line 1", "line 2"]
+            expect(msg.lines).to eq(["line 1", "line 2"])
           end
 
           logfile_logger.expects(:log).never
 
           syslog_logger.expects(:log).with do |msg|
-            msg.lines.should == ["line 1", "line 2"]
+            expect(msg.lines).to eq(["line 1", "line 2"])
           end
 
           Logger.start!
@@ -198,7 +198,7 @@ module Backup
           default_loggers.each { |logger| logger.expects(:log).never }
 
           Logger.info "a message"
-          Logger.messages.first.lines.should == ["a message"]
+          expect(Logger.messages.first.lines).to eq(["a message"])
         end
 
         it "does not instantiate any loggers" do
@@ -207,7 +207,7 @@ module Backup
           Logger::Syslog.expects(:new).never
 
           Logger.info "a message"
-          Logger.send(:logger).instance_variable_get(:@loggers).should be_empty
+          expect(Logger.send(:logger).instance_variable_get(:@loggers)).to be_empty
         end
       end
 
@@ -240,19 +240,19 @@ module Backup
         it "stores and sends messages" do
           default_loggers.each do |logger|
             logger.expects(:log).with do |msg|
-              msg.lines.should == ["a message"]
+              expect(msg.lines).to eq(["a message"])
             end
           end
 
           Logger.start!
           Logger.info "a message"
-          Logger.messages.first.lines.should == ["a message"]
+          expect(Logger.messages.first.lines).to eq(["a message"])
         end
 
         it "instantiates all enabled loggers" do
           Logger.start!
-          Logger.send(:logger).instance_variable_get(:@loggers)
-            .should == default_loggers
+          expect(Logger.send(:logger).instance_variable_get(:@loggers))
+            .to eq(default_loggers)
         end
       end
     end # describe '.start!'
@@ -266,8 +266,8 @@ module Backup
         it "sends messages with log level :info" do
           Logger.info "info message"
           msg = Logger.messages.last
-          msg.level.should == :info
-          msg.lines.should == ["info message"]
+          expect(msg.level).to eq(:info)
+          expect(msg.lines).to eq(["info message"])
 
           default_loggers.each { |logger| logger.expects(:log).with(msg) }
           Logger.start!
@@ -278,8 +278,8 @@ module Backup
         it "sends messages with log level :warn" do
           Logger.warn "warn message"
           msg = Logger.messages.last
-          msg.level.should == :warn
-          msg.lines.should == ["warn message"]
+          expect(msg.level).to eq(:warn)
+          expect(msg.lines).to eq(["warn message"])
 
           default_loggers.each { |logger| logger.expects(:log).with(msg) }
           Logger.start!
@@ -290,8 +290,8 @@ module Backup
         it "sends messages with log level :error" do
           Logger.error "error message"
           msg = Logger.messages.last
-          msg.level.should == :error
-          msg.lines.should == ["error message"]
+          expect(msg.level).to eq(:error)
+          expect(msg.lines).to eq(["error message"])
 
           default_loggers.each { |logger| logger.expects(:log).with(msg) }
           Logger.start!
@@ -301,21 +301,21 @@ module Backup
       it "accepts objects responding to #to_s" do
         Logger.info StandardError.new("message")
         msg = Logger.messages.last
-        msg.level.should == :info
-        msg.lines.should == ["message"]
+        expect(msg.level).to eq(:info)
+        expect(msg.lines).to eq(["message"])
       end
 
       it "preserves blank lines in messages" do
         Logger.info "line one\n\nline two"
         msg = Logger.messages.last
-        msg.level.should == :info
-        msg.lines.should == ["line one", "", "line two"]
+        expect(msg.level).to eq(:info)
+        expect(msg.lines).to eq(["line one", "", "line two"])
       end
 
       it "logs messages with UTC time" do
         Logger.info "message"
         msg = Logger.messages.last
-        msg.time.should be_utc
+        expect(msg.time).to be_utc
       end
     end # describe 'log messaging methods'
 
@@ -323,7 +323,7 @@ module Backup
       context "when messages with :warn log level are sent" do
         it "returns true" do
           Logger.warn "warn message"
-          Logger.has_warnings?.should be_true
+          expect(Logger.has_warnings?).to eq(true)
         end
       end
 
@@ -331,7 +331,7 @@ module Backup
         it "returns false" do
           Logger.info "info message"
           Logger.error "error message"
-          Logger.has_warnings?.should be_false
+          expect(Logger.has_warnings?).to eq(false)
         end
       end
     end
@@ -340,7 +340,7 @@ module Backup
       context "when messages with :error log level are sent" do
         it "returns true" do
           Logger.error "error message"
-          Logger.has_errors?.should be_true
+          expect(Logger.has_errors?).to eq(true)
         end
       end
 
@@ -348,7 +348,7 @@ module Backup
         it "returns false" do
           Logger.info "info message"
           Logger.warn "warn message"
-          Logger.has_errors?.should be_false
+          expect(Logger.has_errors?).to eq(false)
         end
       end
     end
@@ -359,9 +359,9 @@ module Backup
         Logger.warn "warn message"
         Logger.error "error message"
 
-        Logger.messages.count.should be(3)
-        Logger.has_warnings?.should be_true
-        Logger.has_errors?.should be_true
+        expect(Logger.messages.count).to be(3)
+        expect(Logger.has_warnings?).to eq(true)
+        expect(Logger.has_errors?).to eq(true)
 
         @initial_logger = Logger.instance_variable_get(:@logger)
         Logger.clear!
@@ -369,24 +369,24 @@ module Backup
       end
 
       it "clears all stored messages" do
-        Logger.messages.should be_empty
+        expect(Logger.messages).to be_empty
       end
 
       it "resets has_warnings? to false" do
-        Logger.has_warnings?.should be_false
+        expect(Logger.has_warnings?).to eq(false)
       end
 
       it "resets has_errors? to false" do
-        Logger.has_errors?.should be_false
+        expect(Logger.has_errors?).to eq(false)
       end
 
       it "replaces the logger" do
-        @current_logger.should be_a(Backup::Logger)
-        @current_logger.should_not be(@initial_logger)
+        expect(@current_logger).to be_a(Backup::Logger)
+        expect(@current_logger).to_not be(@initial_logger)
       end
 
       it "starts the new logger" do
-        @current_logger.instance_variable_get(:@loggers).should == default_loggers
+        expect(@current_logger.instance_variable_get(:@loggers)).to eq(default_loggers)
       end
     end
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -823,7 +823,7 @@ describe "Backup::Model" do
     context "when name is given as a module defined under Backup::Config::DSL" do
       # this is necessary since the specs in spec/config/dsl_spec.rb
       # remove all the constants from Backup::Config::DSL as part of those tests.
-      before(:all) do
+      before(:context) do
         class Backup::Config::DSL
           module TestScope
             module TestKlass; end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -786,37 +786,25 @@ describe "Backup::Model" do
 
     context "when name is given as a string" do
       it "should return the constant for the given scope and name" do
-        expect(model.send(
-          :get_class_from_scope,
-          Fake,
-          "TestScope"
-        )).to eq(Fake::TestScope)
+        result = model.send(:get_class_from_scope, Fake, "TestScope")
+        expect(result).to eq(Fake::TestScope)
       end
 
       it "should accept a nested class name" do
-        expect(model.send(
-          :get_class_from_scope,
-          Fake,
-          "TestScope::TestKlass"
-        )).to eq(Fake::TestScope::TestKlass)
+        result = model.send(:get_class_from_scope, Fake, "TestScope::TestKlass")
+        expect(result).to eq(Fake::TestScope::TestKlass)
       end
     end
 
     context "when name is given as a module" do
       it "should return the constant for the given scope and name" do
-        expect(model.send(
-          :get_class_from_scope,
-          Fake,
-          TestScope
-        )).to eq(Fake::TestScope)
+        result = model.send(:get_class_from_scope, Fake, TestScope)
+        expect(result).to eq(Fake::TestScope)
       end
 
       it "should accept a nested class name" do
-        expect(model.send(
-          :get_class_from_scope,
-          Fake,
-          TestScope::TestKlass
-        )).to eq(Fake::TestScope::TestKlass)
+        result = model.send(:get_class_from_scope, Fake, TestScope::TestKlass)
+        expect(result).to eq(Fake::TestScope::TestKlass)
       end
     end
 
@@ -832,19 +820,21 @@ describe "Backup::Model" do
       end
 
       it "should return the constant for the given scope and name" do
-        expect(model.send(
+        result = model.send(
           :get_class_from_scope,
           Fake,
           Backup::Config::DSL::TestScope
-        )).to eq(Fake::TestScope)
+        )
+        expect(result).to eq(Fake::TestScope)
       end
 
       it "should accept a nested class name" do
-        expect(model.send(
+        result = model.send(
           :get_class_from_scope,
           Fake,
           Backup::Config::DSL::TestScope::TestKlass
-        )).to eq(Fake::TestScope::TestKlass)
+        )
+        expect(result).to eq(Fake::TestScope::TestKlass)
       end
     end
   end # describe '#get_class_from_scope'

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -9,7 +9,7 @@ describe "Backup::Model" do
 
   describe ".all" do
     it "should be an empty array by default" do
-      Backup::Model.all.should == []
+      expect(Backup::Model.all).to eq([])
     end
   end
 
@@ -22,43 +22,43 @@ describe "Backup::Model" do
 
     it "should return an array of all models matching the trigger" do
       models = Backup::Model.find_by_trigger("trigger_one")
-      models.should be_a(Array)
-      models.count.should be(2)
-      models[0].label.should == "label1"
-      models[1].label.should == "label4"
+      expect(models).to be_a(Array)
+      expect(models.count).to be(2)
+      expect(models[0].label).to eq("label1")
+      expect(models[1].label).to eq("label4")
     end
 
     it "should return an array of all models matching a wildcard trigger" do
       models = Backup::Model.find_by_trigger("trigger_t*")
-      models.count.should be(2)
-      models[0].label.should == "label2"
-      models[1].label.should == "label3"
+      expect(models.count).to be(2)
+      expect(models[0].label).to eq("label2")
+      expect(models[1].label).to eq("label3")
 
       models = Backup::Model.find_by_trigger("trig*ne")
-      models.count.should be(2)
-      models[0].label.should == "label1"
-      models[1].label.should == "label4"
+      expect(models.count).to be(2)
+      expect(models[0].label).to eq("label1")
+      expect(models[1].label).to eq("label4")
 
-      Backup::Model.find_by_trigger("trigg*").count.should be(4)
+      expect(Backup::Model.find_by_trigger("trigg*").count).to be(4)
     end
 
     it "should accept a symbol" do
       models = Backup::Model.find_by_trigger(:trigger_two)
-      models.count.should be(1)
-      models[0].label.should == "label2"
+      expect(models.count).to be(1)
+      expect(models[0].label).to eq("label2")
     end
 
     it "should return an empty array if no matches are found" do
-      Backup::Model.find_by_trigger("foo*").should == []
+      expect(Backup::Model.find_by_trigger("foo*")).to eq([])
     end
   end # describe '.find_by_trigger'
 
   describe ".preconfigure" do
     it "returns preconfiguration block if set" do
       block = proc {}
-      Backup::Model.preconfigure.should be_nil
+      expect(Backup::Model.preconfigure).to be_nil
       Backup::Model.preconfigure(&block)
-      Backup::Model.preconfigure.should be(block)
+      expect(Backup::Model.preconfigure).to be(block)
     end
 
     it "stores preconfiguration for each subclass" do
@@ -68,8 +68,8 @@ describe "Backup::Model" do
       block_b = proc {}
       klass_a.preconfigure(&block_a)
       klass_b.preconfigure(&block_b)
-      klass_a.preconfigure.should be(block_a)
-      klass_b.preconfigure.should be(block_b)
+      expect(klass_a.preconfigure).to be(block_a)
+      expect(klass_b.preconfigure).to be(block_b)
     end
   end
 
@@ -79,38 +79,38 @@ describe "Backup::Model" do
       model_a = klass.new(:model_a, "Model A")
       model_b = Backup::Model.new(:model_b, "Mowel B")
       model_c = klass.new(:model_c, "Model C")
-      Backup::Model.all.should == [model_a, model_b, model_c]
-      Backup::Model.find_by_trigger(:model_c).first.should be(model_c)
+      expect(Backup::Model.all).to eq([model_a, model_b, model_c])
+      expect(Backup::Model.find_by_trigger(:model_c).first).to be(model_c)
     end
   end
 
   describe "#initialize" do
     it "sets default values" do
-      model.trigger.should == "test_trigger"
-      model.label.should == "test label"
-      model.package.should be_an_instance_of Backup::Package
-      model.time.should be_nil
+      expect(model.trigger).to eq("test_trigger")
+      expect(model.label).to eq("test label")
+      expect(model.package).to be_an_instance_of Backup::Package
+      expect(model.time).to be_nil
 
-      model.databases.should == []
-      model.archives.should == []
-      model.storages.should == []
-      model.notifiers.should == []
-      model.syncers.should == []
+      expect(model.databases).to eq([])
+      expect(model.archives).to eq([])
+      expect(model.storages).to eq([])
+      expect(model.notifiers).to eq([])
+      expect(model.syncers).to eq([])
 
-      model.compressor.should be_nil
-      model.encryptor.should be_nil
-      model.splitter.should be_nil
+      expect(model.compressor).to be_nil
+      expect(model.encryptor).to be_nil
+      expect(model.splitter).to be_nil
 
-      model.exit_status.should be_nil
-      model.exception.should be_nil
+      expect(model.exit_status).to be_nil
+      expect(model.exception).to be_nil
     end
 
     it "should convert trigger to a string" do
-      Backup::Model.new(:foo, :bar).trigger.should == "foo"
+      expect(Backup::Model.new(:foo, :bar).trigger).to eq("foo")
     end
 
     it "should convert label to a string" do
-      Backup::Model.new(:foo, :bar).label.should == "bar"
+      expect(Backup::Model.new(:foo, :bar).label).to eq("bar")
     end
 
     it "should accept and instance_eval a block" do
@@ -119,7 +119,7 @@ describe "Backup::Model" do
         before(&before_block)
       end
       model = Backup::Model.new(:foo, "", &block)
-      model.before.should be(before_block)
+      expect(model.before).to be(before_block)
     end
 
     it "should instance_eval the preconfiguration block" do
@@ -129,11 +129,11 @@ describe "Backup::Model" do
         Backup::Model.preconfigure(&pre_config_block)
         Backup::Model.new("foo", "", &model_config_block)
       end
-      caught.should == :pre_config
+      expect(caught).to eq(:pre_config)
     end
 
     it "should add itself to Model.all" do
-      Backup::Model.all.should == [model]
+      expect(Backup::Model.all).to eq([model])
     end
 
     # see also: spec/support/shared_examples/database.rb
@@ -206,14 +206,14 @@ describe "Backup::Model" do
         using_fake("Archive", Fake::TwoArgs::Base) do
           model.archive("foo") { |a| a.block_arg = :foo }
           model.archive("bar") { |a| a.block_arg = :bar }
-          model.archives.count.should == 2
+          expect(model.archives.count).to eq(2)
           a1, a2 = model.archives
-          a1.arg1.should be(model)
-          a1.arg2.should == "foo"
-          a1.block_arg.should == :foo
-          a2.arg1.should be(model)
-          a2.arg2.should == "bar"
-          a2.block_arg.should == :bar
+          expect(a1.arg1).to be(model)
+          expect(a1.arg2).to eq("foo")
+          expect(a1.block_arg).to eq(:foo)
+          expect(a2.arg1).to be(model)
+          expect(a2.arg2).to eq("bar")
+          expect(a2.block_arg).to eq(:bar)
         end
       end
     end
@@ -224,21 +224,21 @@ describe "Backup::Model" do
           model.database("Base", "foo") { |a| a.block_arg = :foo }
           # second arg is optional
           model.database("Base") { |a| a.block_arg = :bar }
-          model.databases.count.should be(2)
+          expect(model.databases.count).to be(2)
           d1, d2 = model.databases
-          d1.arg1.should be(model)
-          d1.arg2.should == "foo"
-          d1.block_arg.should == :foo
-          d2.arg1.should be(model)
-          d2.arg2.should be_nil
-          d2.block_arg.should == :bar
+          expect(d1.arg1).to be(model)
+          expect(d1.arg2).to eq("foo")
+          expect(d1.block_arg).to eq(:foo)
+          expect(d2.arg1).to be(model)
+          expect(d2.arg2).to be_nil
+          expect(d2.block_arg).to eq(:bar)
         end
       end
 
       it "should accept a nested class name" do
         using_fake("Database", Fake) do
           model.database("TwoArgs::Base")
-          model.databases.first.should be_an_instance_of Fake::TwoArgs::Base
+          expect(model.databases.first).to be_an_instance_of Fake::TwoArgs::Base
         end
       end
     end
@@ -249,21 +249,21 @@ describe "Backup::Model" do
           model.store_with("Base", "foo") { |a| a.block_arg = :foo }
           # second arg is optional
           model.store_with("Base") { |a| a.block_arg = :bar }
-          model.storages.count.should be(2)
+          expect(model.storages.count).to be(2)
           s1, s2 = model.storages
-          s1.arg1.should be(model)
-          s1.arg2.should == "foo"
-          s1.block_arg.should == :foo
-          s2.arg1.should be(model)
-          s2.arg2.should be_nil
-          s2.block_arg.should == :bar
+          expect(s1.arg1).to be(model)
+          expect(s1.arg2).to eq("foo")
+          expect(s1.block_arg).to eq(:foo)
+          expect(s2.arg1).to be(model)
+          expect(s2.arg2).to be_nil
+          expect(s2.block_arg).to eq(:bar)
         end
       end
 
       it "should accept a nested class name" do
         using_fake("Storage", Fake) do
           model.store_with("TwoArgs::Base")
-          model.storages.first.should be_an_instance_of Fake::TwoArgs::Base
+          expect(model.storages.first).to be_an_instance_of Fake::TwoArgs::Base
         end
       end
     end
@@ -274,19 +274,19 @@ describe "Backup::Model" do
           model.sync_with("Base", "foo") { |a| a.block_arg = :foo }
           # second arg is optional
           model.sync_with("Base") { |a| a.block_arg = :bar }
-          model.syncers.count.should be(2)
+          expect(model.syncers.count).to be(2)
           s1, s2 = model.syncers
-          s1.arg1.should == "foo"
-          s1.block_arg.should == :foo
-          s2.arg1.should be_nil
-          s2.block_arg.should == :bar
+          expect(s1.arg1).to eq("foo")
+          expect(s1.block_arg).to eq(:foo)
+          expect(s2.arg1).to be_nil
+          expect(s2.block_arg).to eq(:bar)
         end
       end
 
       it "should accept a nested class name" do
         using_fake("Syncer", Fake) do
           model.sync_with("OneArg::Base")
-          model.syncers.first.should be_an_instance_of Fake::OneArg::Base
+          expect(model.syncers.first).to be_an_instance_of Fake::OneArg::Base
         end
       end
     end
@@ -296,19 +296,19 @@ describe "Backup::Model" do
         using_fake("Notifier", Fake::OneArg) do
           model.notify_by("Base") { |a| a.block_arg = :foo }
           model.notify_by("Base") { |a| a.block_arg = :bar }
-          model.notifiers.count.should be(2)
+          expect(model.notifiers.count).to be(2)
           n1, n2 = model.notifiers
-          n1.arg1.should be(model)
-          n1.block_arg.should == :foo
-          n2.arg1.should be(model)
-          n2.block_arg.should == :bar
+          expect(n1.arg1).to be(model)
+          expect(n1.block_arg).to eq(:foo)
+          expect(n2.arg1).to be(model)
+          expect(n2.block_arg).to eq(:bar)
         end
       end
 
       it "should accept a nested class name" do
         using_fake("Notifier", Fake) do
           model.notify_by("OneArg::Base")
-          model.notifiers.first.should be_an_instance_of Fake::OneArg::Base
+          expect(model.notifiers.first).to be_an_instance_of Fake::OneArg::Base
         end
       end
     end
@@ -317,15 +317,15 @@ describe "Backup::Model" do
       it "should add an encryptor" do
         using_fake("Encryptor", Fake::NoArg) do
           model.encrypt_with("Base") { |a| a.block_arg = :foo }
-          model.encryptor.should be_an_instance_of Fake::NoArg::Base
-          model.encryptor.block_arg.should == :foo
+          expect(model.encryptor).to be_an_instance_of Fake::NoArg::Base
+          expect(model.encryptor.block_arg).to eq(:foo)
         end
       end
 
       it "should accept a nested class name" do
         using_fake("Encryptor", Fake) do
           model.encrypt_with("NoArg::Base")
-          model.encryptor.should be_an_instance_of Fake::NoArg::Base
+          expect(model.encryptor).to be_an_instance_of Fake::NoArg::Base
         end
       end
     end
@@ -334,15 +334,15 @@ describe "Backup::Model" do
       it "should add a compressor" do
         using_fake("Compressor", Fake::NoArg) do
           model.compress_with("Base") { |a| a.block_arg = :foo }
-          model.compressor.should be_an_instance_of Fake::NoArg::Base
-          model.compressor.block_arg.should == :foo
+          expect(model.compressor).to be_an_instance_of Fake::NoArg::Base
+          expect(model.compressor.block_arg).to eq(:foo)
         end
       end
 
       it "should accept a nested class name" do
         using_fake("Compressor", Fake) do
           model.compress_with("NoArg::Base")
-          model.compressor.should be_an_instance_of Fake::NoArg::Base
+          expect(model.compressor).to be_an_instance_of Fake::NoArg::Base
         end
       end
     end
@@ -351,10 +351,10 @@ describe "Backup::Model" do
       it "should add a splitter" do
         using_fake("Splitter", Fake::ThreeArgs::Base) do
           model.split_into_chunks_of(123, 2)
-          model.splitter.should be_an_instance_of Fake::ThreeArgs::Base
-          model.splitter.arg1.should be(model)
-          model.splitter.arg2.should == 123
-          model.splitter.arg3.should == 2
+          expect(model.splitter).to be_an_instance_of Fake::ThreeArgs::Base
+          expect(model.splitter.arg1).to be(model)
+          expect(model.splitter.arg2).to eq(123)
+          expect(model.splitter.arg3).to eq(2)
         end
       end
 
@@ -362,8 +362,8 @@ describe "Backup::Model" do
         expect do
           model.split_into_chunks_of("345", 2)
         end.to raise_error { |err|
-          err.should be_an_instance_of Backup::Model::Error
-          err.message.should match(/must be Integers/)
+          expect(err).to be_an_instance_of Backup::Model::Error
+          expect(err.message).to match(/must be Integers/)
         }
       end
 
@@ -371,8 +371,8 @@ describe "Backup::Model" do
         expect do
           model.split_into_chunks_of(345, "2")
         end.to raise_error { |err|
-          err.should be_an_instance_of Backup::Model::Error
-          err.message.should match(/must be Integers/)
+          expect(err).to be_an_instance_of Backup::Model::Error
+          expect(err.message).to match(/must be Integers/)
         }
       end
     end
@@ -394,10 +394,10 @@ describe "Backup::Model" do
       model.perform!
       Timecop.return
 
-      model.started_at.should == started_at
-      model.time.should == time
-      model.package.time.should == time
-      model.finished_at.should == finished_at
+      expect(model.started_at).to eq(started_at)
+      expect(model.time).to eq(time)
+      expect(model.package.time).to eq(time)
+      expect(model.finished_at).to eq(finished_at)
     end
 
     it "performs all procedures" do
@@ -417,16 +417,16 @@ describe "Backup::Model" do
 
       model.perform!
 
-      model.exception.should be_nil
-      model.exit_status.should be 0
+      expect(model.exception).to be_nil
+      expect(model.exit_status).to be 0
     end
 
     describe "exit status" do
       it "sets exit_status to 0 when successful" do
         model.perform!
 
-        model.exception.should be_nil
-        model.exit_status.should be 0
+        expect(model.exception).to be_nil
+        expect(model.exit_status).to be 0
       end
 
       it "sets exit_status to 1 when warnings are logged" do
@@ -434,8 +434,8 @@ describe "Backup::Model" do
 
         model.perform!
 
-        model.exception.should be_nil
-        model.exit_status.should be 1
+        expect(model.exception).to be_nil
+        expect(model.exit_status).to be 1
       end
 
       it "sets exit_status 2 for a StandardError" do
@@ -444,8 +444,8 @@ describe "Backup::Model" do
 
         model.perform!
 
-        model.exception.should == err
-        model.exit_status.should be 2
+        expect(model.exception).to eq(err)
+        expect(model.exit_status).to be 2
       end
 
       it "sets exit_status 3 for an Exception" do
@@ -454,8 +454,8 @@ describe "Backup::Model" do
 
         model.perform!
 
-        model.exception.should == err
-        model.exit_status.should be 3
+        expect(model.exception).to eq(err)
+        expect(model.exit_status).to be 3
       end
     end # context 'when errors occur'
 
@@ -470,9 +470,9 @@ describe "Backup::Model" do
 
         model.perform!
 
-        before_called.should be_true
-        procedure_called.should be_true
-        after_called_with.should be 0
+        expect(before_called).to be_truthy
+        expect(procedure_called).to be_truthy
+        expect(after_called_with).to be 0
       end
 
       specify "before hook may log warnings" do
@@ -484,37 +484,37 @@ describe "Backup::Model" do
 
         model.perform!
 
-        model.exit_status.should be 1
-        procedure_called.should be_true
-        after_called_with.should be 1
+        expect(model.exit_status).to be 1
+        expect(procedure_called).to be_truthy
+        expect(after_called_with).to be 1
       end
 
       specify "before hook may abort model with non-fatal exception" do
-        procedure_called = nil
-        after_called = nil
+        procedure_called = false
+        after_called = false
         model.before { raise StandardError }
         model.stubs(:procedures).returns([-> { procedure_called = true }])
         model.after { after_called = true }
 
         model.perform!
 
-        model.exit_status.should be 2
-        procedure_called.should be_false
-        after_called.should be_false
+        expect(model.exit_status).to be 2
+        expect(procedure_called).to eq(false)
+        expect(after_called).to eq(false)
       end
 
       specify "before hook may abort backup with fatal exception" do
-        procedure_called = nil
-        after_called = nil
+        procedure_called = false
+        after_called = false
         model.before { raise Exception }
         model.stubs(:procedures).returns([-> { procedure_called = true }])
         model.after { after_called = true }
 
         model.perform!
 
-        model.exit_status.should be 3
-        procedure_called.should be_false
-        after_called.should be_false
+        expect(model.exit_status).to be 3
+        expect(procedure_called).to eq(false)
+        expect(after_called).to eq(false)
       end
 
       specify "after hook is called when procedure raises non-fatal exception" do
@@ -524,8 +524,8 @@ describe "Backup::Model" do
 
         model.perform!
 
-        model.exit_status.should be 2
-        after_called_with.should be 2
+        expect(model.exit_status).to be 2
+        expect(after_called_with).to be 2
       end
 
       specify "after hook is called when procedure raises fatal exception" do
@@ -535,8 +535,8 @@ describe "Backup::Model" do
 
         model.perform!
 
-        model.exit_status.should be 3
-        after_called_with.should be 3
+        expect(model.exit_status).to be 3
+        expect(after_called_with).to be 3
       end
 
       specify "after hook may log warnings" do
@@ -548,8 +548,8 @@ describe "Backup::Model" do
 
         model.perform!
 
-        model.exit_status.should be 1
-        after_called_with.should be 0
+        expect(model.exit_status).to be 1
+        expect(after_called_with).to be 0
       end
 
       specify "after hook warnings will not decrease exit_status" do
@@ -562,9 +562,9 @@ describe "Backup::Model" do
 
         model.perform!
 
-        model.exit_status.should be 2
-        after_called_with.should be 2
-        Backup::Logger.has_warnings?.should be_true
+        expect(model.exit_status).to be 2
+        expect(after_called_with).to be 2
+        expect(Backup::Logger.has_warnings?).to be_truthy
       end
 
       specify "after hook may fail model with non-fatal exceptions" do
@@ -577,8 +577,8 @@ describe "Backup::Model" do
 
         model.perform!
 
-        model.exit_status.should be 2
-        after_called_with.should be 1
+        expect(model.exit_status).to be 2
+        expect(after_called_with).to be 1
       end
 
       specify "after hook exception will not decrease exit_status" do
@@ -591,8 +591,8 @@ describe "Backup::Model" do
 
         model.perform!
 
-        model.exit_status.should be 3
-        after_called_with.should be 3
+        expect(model.exit_status).to be 3
+        expect(after_called_with).to be 3
       end
 
       specify "after hook may abort backup with fatal exceptions" do
@@ -605,17 +605,17 @@ describe "Backup::Model" do
 
         model.perform!
 
-        model.exit_status.should be 3
-        after_called_with.should be 2
+        expect(model.exit_status).to be 3
+        expect(after_called_with).to be 2
       end
 
       specify "hooks may be overridden" do
         block_a = proc {}
         block_b = proc {}
         model.before(&block_a)
-        model.before.should be(block_a)
+        expect(model.before).to be(block_a)
         model.before(&block_b)
-        model.before.should be(block_b)
+        expect(model.before).to be(block_b)
       end
     end # describe 'hooks'
   end # describe '#perform!'
@@ -634,14 +634,14 @@ describe "Backup::Model" do
           212_460  => "59:01:00", 212_461  => "59:01:01", 212_519  => "59:01:59",
           215_940  => "59:59:00", 215_941  => "59:59:01", 215_999  => "59:59:59" }.each do |duration, expected|
           model.stubs(:started_at).returns(Time.now - duration)
-          model.duration.should == expected
+          expect(model.duration).to eq(expected)
         end
       end
     end
 
     it "returns nil if job has not finished" do
       model.stubs(:started_at).returns(Time.now)
-      model.duration.should be_nil
+      expect(model.duration).to be_nil
     end
   end # describe '#duration'
 
@@ -655,7 +655,7 @@ describe "Backup::Model" do
 
     context "when no databases or archives are configured" do
       it "returns an empty array" do
-        model.send(:procedures).should == []
+        expect(model.send(:procedures)).to eq([])
       end
     end
 
@@ -666,12 +666,12 @@ describe "Backup::Model" do
 
       it "returns all procedures" do
         one, two, three, four, five, six = model.send(:procedures)
-        one.call.should == :prepare
-        two.should == [:database]
-        three.should == []
-        four.call.should == :package
-        five.call.should == [:storage]
-        six.call.should == :clean
+        expect(one.call).to eq(:prepare)
+        expect(two).to eq([:database])
+        expect(three).to eq([])
+        expect(four.call).to eq(:package)
+        expect(five.call).to eq([:storage])
+        expect(six.call).to eq(:clean)
       end
     end
 
@@ -682,12 +682,12 @@ describe "Backup::Model" do
 
       it "returns all procedures" do
         one, two, three, four, five, six = model.send(:procedures)
-        one.call.should == :prepare
-        two.should == []
-        three.should == [:archive]
-        four.call.should == :package
-        five.call.should == [:storage]
-        six.call.should == :clean
+        expect(one.call).to eq(:prepare)
+        expect(two).to eq([])
+        expect(three).to eq([:archive])
+        expect(four.call).to eq(:package)
+        expect(five.call).to eq([:storage])
+        expect(six.call).to eq(:clean)
       end
     end
   end # describe '#procedures'
@@ -786,37 +786,37 @@ describe "Backup::Model" do
 
     context "when name is given as a string" do
       it "should return the constant for the given scope and name" do
-        model.send(
+        expect(model.send(
           :get_class_from_scope,
           Fake,
           "TestScope"
-        ).should == Fake::TestScope
+        )).to eq(Fake::TestScope)
       end
 
       it "should accept a nested class name" do
-        model.send(
+        expect(model.send(
           :get_class_from_scope,
           Fake,
           "TestScope::TestKlass"
-        ).should == Fake::TestScope::TestKlass
+        )).to eq(Fake::TestScope::TestKlass)
       end
     end
 
     context "when name is given as a module" do
       it "should return the constant for the given scope and name" do
-        model.send(
+        expect(model.send(
           :get_class_from_scope,
           Fake,
           TestScope
-        ).should == Fake::TestScope
+        )).to eq(Fake::TestScope)
       end
 
       it "should accept a nested class name" do
-        model.send(
+        expect(model.send(
           :get_class_from_scope,
           Fake,
           TestScope::TestKlass
-        ).should == Fake::TestScope::TestKlass
+        )).to eq(Fake::TestScope::TestKlass)
       end
     end
 
@@ -832,19 +832,19 @@ describe "Backup::Model" do
       end
 
       it "should return the constant for the given scope and name" do
-        model.send(
+        expect(model.send(
           :get_class_from_scope,
           Fake,
           Backup::Config::DSL::TestScope
-        ).should == Fake::TestScope
+        )).to eq(Fake::TestScope)
       end
 
       it "should accept a nested class name" do
-        model.send(
+        expect(model.send(
           :get_class_from_scope,
           Fake,
           Backup::Config::DSL::TestScope::TestKlass
-        ).should == Fake::TestScope::TestKlass
+        )).to eq(Fake::TestScope::TestKlass)
       end
     end
   end # describe '#get_class_from_scope'
@@ -853,7 +853,7 @@ describe "Backup::Model" do
     context "when the model completed successfully without warnings" do
       it "sets exit status to 0" do
         model.send(:set_exit_status)
-        model.exit_status.should be(0)
+        expect(model.exit_status).to be(0)
       end
     end
 
@@ -862,7 +862,7 @@ describe "Backup::Model" do
 
       it "sets exit status to 1" do
         model.send(:set_exit_status)
-        model.exit_status.should be(1)
+        expect(model.exit_status).to be(1)
       end
     end
 
@@ -871,7 +871,7 @@ describe "Backup::Model" do
 
       it "sets exit status to 2" do
         model.send(:set_exit_status)
-        model.exit_status.should be(2)
+        expect(model.exit_status).to be(2)
       end
     end
 
@@ -880,7 +880,7 @@ describe "Backup::Model" do
 
       it "sets exit status to 3" do
         model.send(:set_exit_status)
-        model.exit_status.should be(3)
+        expect(model.exit_status).to be(3)
       end
     end
   end # describe '#set_exit_status'
@@ -934,8 +934,8 @@ describe "Backup::Model" do
 
         it "logs that the backup failed with a non-fatal exception" do
           Backup::Model::Error.expects(:wrap).in_sequence(s).with do |err, msg|
-            err.message.should == "non-fatal error"
-            msg.should match(/Backup for test label \(test_trigger\) Failed!/)
+            expect(err.message).to eq("non-fatal error")
+            expect(msg).to match(/Backup for test label \(test_trigger\) Failed!/)
           end.returns(error_a)
           Backup::Logger.expects(:error).in_sequence(s).with(error_a)
           Backup::Logger.expects(:error).in_sequence(s).with(
@@ -959,8 +959,8 @@ describe "Backup::Model" do
 
         it "logs that the backup failed with a fatal exception" do
           Backup::Model::FatalError.expects(:wrap).in_sequence(s).with do |err, msg|
-            err.message.should == "fatal error"
-            msg.should match(/Backup for test label \(test_trigger\) Failed!/)
+            expect(err.message).to eq("fatal error")
+            expect(msg).to match(/Backup for test label \(test_trigger\) Failed!/)
           end.returns(error_a)
           Backup::Logger.expects(:error).in_sequence(s).with(error_a)
           Backup::Logger.expects(:error).in_sequence(s).with(

--- a/spec/notifier/flowdock_spec.rb
+++ b/spec/notifier/flowdock_spec.rb
@@ -63,7 +63,7 @@ module Backup
         end
       end
       let(:client) { mock }
-      let(:push_to_team_inbox) { mock }
+      let(:push_to_team_inbox) { double }
       let(:message) { "[Backup::%s] test label (test_trigger)" }
 
       context "when status is :success" do

--- a/spec/notifier/mail_spec.rb
+++ b/spec/notifier/mail_spec.rb
@@ -130,7 +130,7 @@ module Backup
             filename = "#{model.time}.#{model.trigger}.log"
 
             expect(sent_message.subject).to eq message % "Success"
-            expect(sent_message.body.multipart?).to be_true
+            expect(sent_message.body.multipart?).to eq(true)
             expect(sent_message.attachments[filename].read)
               .to eq "line 1\nline 2\nline 3"
             expect(sent_message.text_part).to be_an_instance_of ::Mail::Part
@@ -162,8 +162,8 @@ module Backup
 
             sent_message = ::Mail::TestMailer.deliveries.first
             expect(sent_message.subject).to eq message % "Success"
-            expect(sent_message.multipart?).to be_false
-            expect(sent_message.has_attachments?).to be_false
+            expect(sent_message.multipart?).to eq(false)
+            expect(sent_message.has_attachments?).to eq(false)
             expect(sent_message.body).to be_an_instance_of ::Mail::Body
             expect(sent_message.body.decoded).to eq <<-EOS.gsub(/^ +/, "")
 
@@ -195,7 +195,7 @@ module Backup
             filename = "#{model.time}.#{model.trigger}.log"
 
             expect(sent_message.subject).to eq message % "Warning"
-            expect(sent_message.body.multipart?).to be_true
+            expect(sent_message.body.multipart?).to eq(true)
             expect(sent_message.attachments[filename].read)
               .to eq "line 1\nline 2\nline 3"
             expect(sent_message.text_part).to be_an_instance_of ::Mail::Part
@@ -229,8 +229,8 @@ module Backup
 
             sent_message = ::Mail::TestMailer.deliveries.first
             expect(sent_message.subject).to eq message % "Warning"
-            expect(sent_message.multipart?).to be_false
-            expect(sent_message.has_attachments?).to be_false
+            expect(sent_message.multipart?).to eq(false)
+            expect(sent_message.has_attachments?).to eq(false)
             expect(sent_message.body).to be_an_instance_of ::Mail::Body
             expect(sent_message.body.decoded).to eq <<-EOS.gsub(/^ +/, "")
 
@@ -262,7 +262,7 @@ module Backup
             filename = "#{model.time}.#{model.trigger}.log"
 
             expect(sent_message.subject).to eq message % "Failure"
-            expect(sent_message.body.multipart?).to be_true
+            expect(sent_message.body.multipart?).to eq(true)
             expect(sent_message.attachments[filename].read)
               .to eq "line 1\nline 2\nline 3"
             expect(sent_message.text_part).to be_an_instance_of ::Mail::Part
@@ -296,8 +296,8 @@ module Backup
 
             sent_message = ::Mail::TestMailer.deliveries.first
             expect(sent_message.subject).to eq message % "Failure"
-            expect(sent_message.multipart?).to be_false
-            expect(sent_message.has_attachments?).to be_false
+            expect(sent_message.multipart?).to eq(false)
+            expect(sent_message.has_attachments?).to eq(false)
             expect(sent_message.body).to be_an_instance_of ::Mail::Body
             expect(sent_message.body.decoded).to eq <<-EOS.gsub(/^ +/, "")
 

--- a/spec/notifier/pagerduty_spec.rb
+++ b/spec/notifier/pagerduty_spec.rb
@@ -8,7 +8,7 @@ module Backup
     describe "#initialize" do
       it "has sensible defaults" do
         expect(notifier.service_key).to be_nil
-        expect(notifier.resolve_on_warning).to be_false
+        expect(notifier.resolve_on_warning).to eq(false)
       end
 
       it "yields to allow modifying defaults" do

--- a/spec/packager_spec.rb
+++ b/spec/packager_spec.rb
@@ -4,8 +4,8 @@ describe "Backup::Packager" do
   let(:packager) { Backup::Packager }
 
   it "should include Utilities::Helpers" do
-    packager.instance_eval("class << self; self; end")
-      .include?(Backup::Utilities::Helpers).should be_true
+    expect(packager.instance_eval("class << self; self; end")
+      .include?(Backup::Utilities::Helpers)).to eq(true)
   end
 
   describe "#package!" do
@@ -37,10 +37,10 @@ describe "Backup::Packager" do
 
         packager.package!(model)
 
-        packager.instance_variable_get(:@package).should be(package)
-        packager.instance_variable_get(:@encryptor).should be(encryptor)
-        packager.instance_variable_get(:@splitter).should be(splitter)
-        packager.instance_variable_get(:@pipeline).should be(pipeline)
+        expect(packager.instance_variable_get(:@package)).to be(package)
+        expect(packager.instance_variable_get(:@encryptor)).to be(encryptor)
+        expect(packager.instance_variable_get(:@splitter)).to be(splitter)
+        expect(packager.instance_variable_get(:@pipeline)).to be(pipeline)
       end
     end # context 'when pipeline command is successful'
 
@@ -68,10 +68,10 @@ describe "Backup::Packager" do
           "  pipeline_errors"
         )
 
-        packager.instance_variable_get(:@package).should be(package)
-        packager.instance_variable_get(:@encryptor).should be(encryptor)
-        packager.instance_variable_get(:@splitter).should be(splitter)
-        packager.instance_variable_get(:@pipeline).should be(pipeline)
+        expect(packager.instance_variable_get(:@package)).to be(package)
+        expect(packager.instance_variable_get(:@encryptor)).to be(encryptor)
+        expect(packager.instance_variable_get(:@splitter)).to be(splitter)
+        expect(packager.instance_variable_get(:@pipeline)).to be(pipeline)
       end
     end # context 'when pipeline command is successful'
   end # describe '#package!'
@@ -156,9 +156,9 @@ describe "Backup::Packager" do
 
         packager.send(:procedure).call
 
-        Fake.stack_trace.should == [
+        expect(Fake.stack_trace).to eq([
           :encryptor_before, :command_executed, :encryptor_after
-        ]
+        ])
       end
     end
 
@@ -180,9 +180,9 @@ describe "Backup::Packager" do
 
         packager.send(:procedure).call
 
-        Fake.stack_trace.should == [
+        expect(Fake.stack_trace).to eq([
           :splitter_before, :command_executed, :splitter_after
-        ]
+        ])
       end
     end
 
@@ -205,12 +205,12 @@ describe "Backup::Packager" do
 
         packager.send(:procedure).call
 
-        Fake.stack_trace.should == [
+        expect(Fake.stack_trace).to eq([
           :encryptor_before, :splitter_before,
           :command_executed,
           :splitter_after, :encryptor_after
-        ]
-        package.extension.should == "tar.enc"
+        ])
+        expect(package.extension).to eq("tar.enc")
       end
     end
   end # describe '#procedure'

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -4,30 +4,30 @@ describe "Backup::Pipeline" do
   let(:pipeline) { Backup::Pipeline.new }
 
   it "should include Utilities::Helpers" do
-    Backup::Pipeline
-      .include?(Backup::Utilities::Helpers).should be_true
+    expect(Backup::Pipeline
+      .include?(Backup::Utilities::Helpers)).to eq(true)
   end
 
   describe "#initialize" do
     it "should create a new pipeline" do
-      pipeline.instance_variable_get(:@commands).should == []
-      pipeline.instance_variable_get(:@success_codes).should == []
-      pipeline.errors.should == []
-      pipeline.stderr.should == ""
+      expect(pipeline.instance_variable_get(:@commands)).to eq([])
+      expect(pipeline.instance_variable_get(:@success_codes)).to eq([])
+      expect(pipeline.errors).to eq([])
+      expect(pipeline.stderr).to eq("")
     end
   end
 
   describe "#add" do
     it "should add a command with the given successful exit codes" do
       pipeline.add "a command", [0]
-      pipeline.instance_variable_get(:@commands).should == ["a command"]
-      pipeline.instance_variable_get(:@success_codes).should == [[0]]
+      expect(pipeline.instance_variable_get(:@commands)).to eq(["a command"])
+      expect(pipeline.instance_variable_get(:@success_codes)).to eq([[0]])
 
       pipeline.add "another command", [1, 3]
-      pipeline.instance_variable_get(:@commands)
-        .should == ["a command", "another command"]
-      pipeline.instance_variable_get(:@success_codes)
-        .should == [[0], [1, 3]]
+      expect(pipeline.instance_variable_get(:@commands))
+        .to eq(["a command", "another command"])
+      expect(pipeline.instance_variable_get(:@success_codes))
+        .to eq([[0], [1, 3]])
     end
   end
 
@@ -70,8 +70,8 @@ describe "Backup::Pipeline" do
             Backup::Logger.expects(:warn).never
 
             pipeline.run
-            pipeline.stderr.should == ""
-            pipeline.errors.should == []
+            expect(pipeline.stderr).to eq("")
+            expect(pipeline.errors).to eq([])
           end
         end
 
@@ -85,8 +85,8 @@ describe "Backup::Pipeline" do
             Backup::Logger.expects(:warn).with("stderr_messages_output")
 
             pipeline.run
-            pipeline.stderr.should == "stderr output"
-            pipeline.errors.should == []
+            expect(pipeline.stderr).to eq("stderr output")
+            expect(pipeline.errors).to eq([])
           end
         end
       end # context 'when all commands within the pipeline are successful'
@@ -108,11 +108,11 @@ describe "Backup::Pipeline" do
             Backup::Logger.expects(:warn).never
 
             pipeline.run
-            pipeline.stderr.should == "stderr output"
-            pipeline.errors.count.should be(1)
-            pipeline.errors.first.should be_a_kind_of SystemCallError
-            pipeline.errors.first.errno.should be(1)
-            pipeline.errors.first.message.should match(
+            expect(pipeline.stderr).to eq("stderr output")
+            expect(pipeline.errors.count).to be(1)
+            expect(pipeline.errors.first).to be_a_kind_of SystemCallError
+            expect(pipeline.errors.first.errno).to be(1)
+            expect(pipeline.errors.first.message).to match(
               "'second' returned exit code: 1"
             )
           end
@@ -127,11 +127,11 @@ describe "Backup::Pipeline" do
             Backup::Logger.expects(:warn).never
 
             pipeline.run
-            pipeline.stderr.should == "stderr output"
-            pipeline.errors.count.should be(1)
-            pipeline.errors.first.should be_a_kind_of SystemCallError
-            pipeline.errors.first.errno.should be(4)
-            pipeline.errors.first.message.should match(
+            expect(pipeline.stderr).to eq("stderr output")
+            expect(pipeline.errors.count).to be(1)
+            expect(pipeline.errors.first).to be_a_kind_of SystemCallError
+            expect(pipeline.errors.first.errno).to be(4)
+            expect(pipeline.errors.first.message).to match(
               "'third' returned exit code: 4"
             )
           end
@@ -146,15 +146,15 @@ describe "Backup::Pipeline" do
             Backup::Logger.expects(:warn).never
 
             pipeline.run
-            pipeline.stderr.should == "stderr output"
-            pipeline.errors.count.should be(2)
-            pipeline.errors.each { |err| err.should be_a_kind_of SystemCallError }
-            pipeline.errors[0].errno.should be(3)
-            pipeline.errors[0].message.should match(
+            expect(pipeline.stderr).to eq("stderr output")
+            expect(pipeline.errors.count).to be(2)
+            pipeline.errors.each { |err| expect(err).to be_a_kind_of SystemCallError }
+            expect(pipeline.errors[0].errno).to be(3)
+            expect(pipeline.errors[0].message).to match(
               "'first' returned exit code: 3"
             )
-            pipeline.errors[1].errno.should be(1)
-            pipeline.errors[1].message.should match(
+            expect(pipeline.errors[1].errno).to be(1)
+            expect(pipeline.errors[1].message).to match(
               "'second' returned exit code: 1"
             )
           end
@@ -171,7 +171,7 @@ describe "Backup::Pipeline" do
         expect do
           pipeline.run
         end.to raise_error(Backup::Pipeline::Error) { |err|
-          err.message.should eq(
+          expect(err.message).to eq(
             "Pipeline::Error: Pipeline failed to execute\n" \
             "--- Wrapped Exception ---\n" \
             "RuntimeError: exec failed"
@@ -183,12 +183,12 @@ describe "Backup::Pipeline" do
 
   describe "#success?" do
     it "returns true when @errors is empty" do
-      pipeline.success?.should be_true
+      expect(pipeline.success?).to eq(true)
     end
 
     it "returns false when @errors is not empty" do
       pipeline.instance_variable_set(:@errors, ["foo"])
-      pipeline.success?.should be_false
+      expect(pipeline.success?).to eq(false)
     end
   end # describe '#success?'
 
@@ -211,7 +211,7 @@ describe "Backup::Pipeline" do
       end
 
       it "should output #stderr_messages and formatted system error messages" do
-        pipeline.error_messages.should match(/
+        expect(pipeline.error_messages).to match(/
           stderr\smessages\n
           The\sfollowing\ssystem\serrors\swere\sreturned:\n
           #{ sys_err }:\s(.*?)\sfirst\serror\n
@@ -226,7 +226,7 @@ describe "Backup::Pipeline" do
       end
 
       it "should only output the formatted system error messages" do
-        pipeline.error_messages.should match(/
+        expect(pipeline.error_messages).to match(/
           stderr\smessages\n
           The\sfollowing\ssystem\serrors\swere\sreturned:\n
           #{ sys_err }:\s(.*?)\sfirst\serror\n
@@ -243,10 +243,11 @@ describe "Backup::Pipeline" do
       end
 
       it "should build a pipeline with redirected/collected exit codes" do
-        pipeline.send(:pipeline).should ==
+        expect(pipeline.send(:pipeline)).to eq(
           '{ { one 2>&4 ; echo "0|$?:" >&3 ; } | ' \
           '{ two 2>&4 ; echo "1|$?:" >&3 ; } | ' \
           '{ three 2>&4 ; echo "2|$?:" >&3 ; } } 3>&1 1>&2 4>&2'
+        )
       end
     end
 
@@ -256,8 +257,9 @@ describe "Backup::Pipeline" do
       end
 
       it "should build the command line in the same manner, but without pipes" do
-        pipeline.send(:pipeline).should ==
+        expect(pipeline.send(:pipeline)).to eq(
           '{ { foo 2>&4 ; echo "0|$?:" >&3 ; } } 3>&1 1>&2 4>&2'
+        )
       end
     end
   end # describe '#pipeline'
@@ -269,18 +271,19 @@ describe "Backup::Pipeline" do
       end
 
       it "should return a formatted message with the @stderr messages" do
-        pipeline.send(:stderr_messages).should ==
+        expect(pipeline.send(:stderr_messages)).to eq(
           "  Pipeline STDERR Messages:\n" \
           "  (Note: may be interleaved if multiple commands returned error messages)\n" \
           "\n" \
           "  stderr message\n" \
           "  output\n"
+        )
       end
     end
 
     context "when @stderr is empty" do
       it "should return false" do
-        pipeline.send(:stderr_messages).should be_false
+        expect(pipeline.send(:stderr_messages)).to eq(false)
       end
     end
   end # describe '#stderr_message'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,6 @@ module Backup
   end
 end
 
-require "rspec/autorun"
 RSpec.configure do |config|
   ##
   # Use Mocha to mock with RSpec
@@ -42,7 +41,6 @@ RSpec.configure do |config|
 
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
-  config.treat_symbols_as_metadata_keys_with_true_values = true
 
   config.before(:suite) do
     # Initializes SandboxFileUtils so the first call to deactivate!(:noop)
@@ -50,7 +48,7 @@ RSpec.configure do |config|
     SandboxFileUtils.activate!
   end
 
-  config.before(:each) do
+  config.before(:example) do
     # ::FileUtils will always be either SandboxFileUtils or FileUtils::NoWrite.
     SandboxFileUtils.deactivate!(:noop)
 

--- a/spec/storage/cloud_files_spec.rb
+++ b/spec/storage/cloud_files_spec.rb
@@ -218,7 +218,7 @@ module Backup
 
         storage.send(:transfer!)
 
-        expect(storage.package.no_cycle).to be_false
+        expect(storage.package.no_cycle).to eq(false)
       end
 
       context "when days_to_keep is set" do
@@ -227,7 +227,7 @@ module Backup
         it "marks package so the cycler will not attempt to remove it" do
           cloud_io.stubs(:upload)
           storage.send(:transfer!)
-          expect(storage.package.no_cycle).to be_true
+          expect(storage.package.no_cycle).to eq(true)
         end
       end
     end # describe '#transfer!'

--- a/spec/storage/dropbox_spec.rb
+++ b/spec/storage/dropbox_spec.rb
@@ -66,12 +66,12 @@ module Backup
         end
 
         it "uses the cached session to create the client" do
-          storage.send(:connection).should be(client)
+          expect(storage.send(:connection)).to be(client)
         end
 
         it "returns an already existing client" do
-          storage.send(:connection).should be(client)
-          storage.send(:connection).should be(client)
+          expect(storage.send(:connection)).to be(client)
+          expect(storage.send(:connection)).to be(client)
         end
       end
 
@@ -84,12 +84,12 @@ module Backup
         end
 
         it "creates a new session and returns the client" do
-          storage.send(:connection).should be(client)
+          expect(storage.send(:connection)).to be(client)
         end
 
         it "returns an already existing client" do
-          storage.send(:connection).should be(client)
-          storage.send(:connection).should be(client)
+          expect(storage.send(:connection)).to be(client)
+          expect(storage.send(:connection)).to be(client)
         end
       end
 
@@ -126,7 +126,7 @@ module Backup
         DropboxSession.expects(:deserialize).with("yaml_data").returns(session)
         Backup::Logger.expects(:info).with("Session data loaded from cache!")
 
-        storage.send(:cached_session).should be(session)
+        expect(storage.send(:cached_session)).to be(session)
       end
 
       it "returns false when no cached session file exists" do
@@ -451,7 +451,7 @@ module Backup
             "storage/dropbox/cache_file_written.erb"
           )
 
-          storage.send(:create_write_and_return_new_session!).should be(session)
+          expect(storage.send(:create_write_and_return_new_session!)).to be(session)
         end
       end
 

--- a/spec/support/very_specific_error.rb
+++ b/spec/support/very_specific_error.rb
@@ -1,0 +1,1 @@
+class VerySpecificError < StandardError; end

--- a/spec/syncer/cloud/local_file_spec.rb
+++ b/spec/syncer/cloud/local_file_spec.rb
@@ -33,7 +33,7 @@ module Backup
 
         # This fails on OSX, see https://github.com/backup/backup/issues/482
         # for more information.
-        it "returns a Hash of LocalFile objects, keyed by relative path", pending: RUBY_PLATFORM =~ /darwin/ do
+        it "returns a Hash of LocalFile objects, keyed by relative path", skip: RUBY_PLATFORM =~ /darwin/ do
           Dir.chdir(@tmpdir) do
             bad_file = "sync_dir/bad\xFFfile"
             sanitized_bad_file = "sync_dir/bad\xEF\xBF\xBDfile"

--- a/spec/syncer/rsync/pull_spec.rb
+++ b/spec/syncer/rsync/pull_spec.rb
@@ -92,12 +92,12 @@ module Backup
 
         it "ensures temporary password file removal" do
           syncer.expects(:write_password_file!).in_sequence(s)
-          syncer.expects(:run).in_sequence(s).raises("error")
+          syncer.expects(:run).in_sequence(s).raises(VerySpecificError)
           syncer.expects(:remove_password_file!).in_sequence(s)
 
           expect do
             syncer.perform!
-          end.to raise_error
+          end.to raise_error(VerySpecificError)
         end
       end # describe 'password handling'
 

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -54,14 +54,14 @@ describe Backup::Utilities do
 
     it "allows utilities to be configured" do
       utilities::NAMES.each do |name|
-        helpers.send(:utility, name).should == "/path/to/#{name}"
+        expect(helpers.send(:utility, name)).to eq("/path/to/#{name}")
       end
     end
 
     it "presets gnu_tar? value to true" do
       utilities.expects(:run).never
-      utilities.gnu_tar?.should be(true)
-      helpers.send(:gnu_tar?).should be(true)
+      expect(utilities.gnu_tar?).to be(true)
+      expect(helpers.send(:gnu_tar?)).to be(true)
     end
 
     it "presets gnu_tar? value to false" do
@@ -70,8 +70,8 @@ describe Backup::Utilities do
       end
 
       utilities.expects(:run).never
-      utilities.gnu_tar?.should be(false)
-      helpers.send(:gnu_tar?).should be(false)
+      expect(utilities.gnu_tar?).to be(false)
+      expect(helpers.send(:gnu_tar?)).to be(false)
     end
 
     it "expands relative paths" do
@@ -79,8 +79,8 @@ describe Backup::Utilities do
         tar "my_tar"
       end
       path = File.expand_path("my_tar")
-      utilities::UTILITY["tar"].should == path
-      helpers.send(:utility, :tar).should == path
+      expect(utilities::UTILITY["tar"]).to eq(path)
+      expect(helpers.send(:utility, :tar)).to eq(path)
     end
 
     it "raises Error if utility is not found or executable" do
@@ -103,8 +103,8 @@ describe Backup::Utilities do
       utilities.expects(:run).with("tar --version").returns(
         'tar (GNU tar) 1.26\nCopyright (C) 2011 Free Software Foundation, Inc.'
       )
-      utilities.gnu_tar?.should be(true)
-      utilities.instance_variable_get(:@gnu_tar).should be(true)
+      expect(utilities.gnu_tar?).to be(true)
+      expect(utilities.instance_variable_get(:@gnu_tar)).to be(true)
     end
 
     it "determines when tar is BSD tar" do
@@ -112,20 +112,20 @@ describe Backup::Utilities do
       utilities.expects(:run).with("tar --version").returns(
         "bsdtar 3.0.4 - libarchive 3.0.4"
       )
-      utilities.gnu_tar?.should be(false)
-      utilities.instance_variable_get(:@gnu_tar).should be(false)
+      expect(utilities.gnu_tar?).to be(false)
+      expect(utilities.instance_variable_get(:@gnu_tar)).to be(false)
     end
 
     it "returns cached true value" do
       utilities.instance_variable_set(:@gnu_tar, true)
       utilities.expects(:run).never
-      utilities.gnu_tar?.should be(true)
+      expect(utilities.gnu_tar?).to be(true)
     end
 
     it "returns cached false value" do
       utilities.instance_variable_set(:@gnu_tar, false)
       utilities.expects(:run).never
-      utilities.gnu_tar?.should be(false)
+      expect(utilities.gnu_tar?).to be(false)
     end
   end
 end # describe Backup::Utilities
@@ -142,15 +142,15 @@ describe Backup::Utilities::Helpers do
     context "when a system path for the utility is available" do
       it "should return the system path with newline removed" do
         utilities.expects(:`).with("which 'foo' 2>/dev/null").returns("system_path\n")
-        helpers.send(:utility, :foo).should == "system_path"
+        expect(helpers.send(:utility, :foo)).to eq("system_path")
       end
 
       it "should cache the returned path" do
         utilities.expects(:`).once.with("which 'cache_me' 2>/dev/null")
           .returns("cached_path\n")
 
-        helpers.send(:utility, :cache_me).should == "cached_path"
-        helpers.send(:utility, :cache_me).should == "cached_path"
+        expect(helpers.send(:utility, :cache_me)).to eq("cached_path")
+        expect(helpers.send(:utility, :cache_me)).to eq("cached_path")
       end
 
       it "should return a mutable copy of the path" do
@@ -158,17 +158,17 @@ describe Backup::Utilities::Helpers do
           .returns("cached_path\n")
 
         helpers.send(:utility, :cache_me) << "foo"
-        helpers.send(:utility, :cache_me).should == "cached_path"
+        expect(helpers.send(:utility, :cache_me)).to eq("cached_path")
       end
 
       it "should cache the value for all extended objects" do
         utilities.expects(:`).once.with("which 'once_only' 2>/dev/null")
           .returns("cached_path\n")
 
-        helpers.send(:utility, :once_only).should == "cached_path"
-        Class.new.extend(Backup::Utilities::Helpers).send(
+        expect(helpers.send(:utility, :once_only)).to eq("cached_path")
+        expect(Class.new.extend(Backup::Utilities::Helpers).send(
           :utility, :once_only
-        ).should == "cached_path"
+        )).to eq("cached_path")
       end
     end
 
@@ -178,7 +178,7 @@ describe Backup::Utilities::Helpers do
       expect do
         helpers.send(:utility, :unknown)
       end.to raise_error(Backup::Utilities::Error) { |err|
-        err.message.should match(/Could not locate 'unknown'/)
+        expect(err.message).to match(/Could not locate 'unknown'/)
       }
     end
 
@@ -269,7 +269,7 @@ describe Backup::Utilities::Helpers do
         let(:stderr_messages) { "" }
 
         it "should return stdout and generate no additional log messages" do
-          helpers.send(:run, command).should == ""
+          expect(helpers.send(:run, command)).to eq("")
         end
       end
 
@@ -281,7 +281,7 @@ describe Backup::Utilities::Helpers do
           Backup::Logger.expects(:info).with(
             "cmd_name:STDOUT: out line1\ncmd_name:STDOUT: out line2"
           )
-          helpers.send(:run, command).should == stdout_messages.strip
+          expect(helpers.send(:run, command)).to eq(stdout_messages.strip)
         end
       end
 
@@ -293,7 +293,7 @@ describe Backup::Utilities::Helpers do
           Backup::Logger.expects(:warn).with(
             "cmd_name:STDERR: err line1\ncmd_name:STDERR: err line2"
           )
-          helpers.send(:run, command).should == ""
+          expect(helpers.send(:run, command)).to eq("")
         end
       end
 
@@ -308,7 +308,7 @@ describe Backup::Utilities::Helpers do
           Backup::Logger.expects(:warn).with(
             "cmd_name:STDERR: err line1\ncmd_name:STDERR: err line2"
           )
-          helpers.send(:run, command).should == stdout_messages.strip
+          expect(helpers.send(:run, command)).to eq(stdout_messages.strip)
         end
       end
     end # context 'when the command is successful'
@@ -339,9 +339,9 @@ describe Backup::Utilities::Helpers do
           expect do
             helpers.send(:run, command)
           end.to raise_error { |err|
-            err.message.should == message_head +
+            expect(err.message).to eq(message_head +
               "  STDOUT Messages: None\n" \
-              "  STDERR Messages: None"
+              "  STDERR Messages: None")
           }
         end
       end
@@ -354,11 +354,11 @@ describe Backup::Utilities::Helpers do
           expect do
             helpers.send(:run, command)
           end.to raise_error { |err|
-            err.message.should == message_head +
+            expect(err.message).to eq(message_head +
               "  STDOUT Messages: \n" \
               "  out line1\n" \
               "  out line2\n" \
-              "  STDERR Messages: None"
+              "  STDERR Messages: None")
           }
         end
       end
@@ -371,11 +371,11 @@ describe Backup::Utilities::Helpers do
           expect do
             helpers.send(:run, command)
           end.to raise_error { |err|
-            err.message.should == message_head +
+            expect(err.message).to eq(message_head +
               "  STDOUT Messages: None\n" \
               "  STDERR Messages: \n" \
               "  err line1\n" \
-              "  err line2"
+              "  err line2")
           }
         end
       end
@@ -388,13 +388,13 @@ describe Backup::Utilities::Helpers do
           expect do
             helpers.send(:run, command)
           end.to raise_error { |err|
-            err.message.should == message_head +
+            expect(err.message).to eq(message_head +
               "  STDOUT Messages: \n" \
               "  out line1\n" \
               "  out line2\n" \
               "  STDERR Messages: \n" \
               "  err line1\n" \
-              "  err line2"
+              "  err line2")
           }
         end
       end
@@ -413,8 +413,8 @@ describe Backup::Utilities::Helpers do
         expect do
           helpers.send(:run, command)
         end.to raise_error(Backup::Utilities::Error) { |err|
-          err.message.should match("Failed to execute 'cmd_name'")
-          err.message.should match("RuntimeError: exec call failed")
+          expect(err.message).to match("Failed to execute 'cmd_name'")
+          expect(err.message).to match("RuntimeError: exec call failed")
         }
       end
     end # context 'when the system fails to execute the command'
@@ -423,12 +423,12 @@ describe Backup::Utilities::Helpers do
   describe "gnu_tar?" do
     it "returns true if tar_dist is gnu" do
       Backup::Utilities.stubs(:gnu_tar?).returns(true)
-      helpers.send(:gnu_tar?).should be(true)
+      expect(helpers.send(:gnu_tar?)).to be(true)
     end
 
     it "returns false if tar_dist is bsd" do
       Backup::Utilities.stubs(:gnu_tar?).returns(false)
-      helpers.send(:gnu_tar?).should be(false)
+      expect(helpers.send(:gnu_tar?)).to be(false)
     end
   end
 end # describe Backup::Utilities::Helpers

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -166,9 +166,10 @@ describe Backup::Utilities::Helpers do
           .returns("cached_path\n")
 
         expect(helpers.send(:utility, :once_only)).to eq("cached_path")
-        expect(Class.new.extend(Backup::Utilities::Helpers).send(
+        result = Class.new.extend(Backup::Utilities::Helpers).send(
           :utility, :once_only
-        )).to eq("cached_path")
+        )
+        expect(result).to eq("cached_path")
       end
     end
 


### PR DESCRIPTION
Upgrade to RSpec version 3.5. Previously version 2.14

This guide was followed: http://rspec.info/upgrading-from-rspec-2/

Conversion of outdated syntax was done with [Transpec](https://github.com/yujinakayama/transpec#transpec), using this command:

```
transpec --boolean-matcher truthy,falsy --convert hook_scope,stub_with_hash --negative-form to_not
```

Closes #824