### PR TITLE
Deprecate certain Backup features

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -69,7 +69,7 @@ Metrics/BlockNesting:
 # Offense count: 10
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 225
+  Max: 263
 
 # Offense count: 11
 Metrics/CyclomaticComplexity:

--- a/lib/backup/model.rb
+++ b/lib/backup/model.rb
@@ -3,6 +3,18 @@ module Backup
     class Error < Backup::Error; end
     class FatalError < Backup::FatalError; end
 
+    DEPRECATED_MODULES = %w[
+      Campfire
+      CloudFiles
+      FTP
+      Nagios
+      OpenLDAP
+      Prowl
+      Riak
+      Twitter
+      Zabbix
+    ].freeze
+
     class << self
       ##
       # The Backup::Model.all class method keeps track of all the models
@@ -140,6 +152,12 @@ module Backup
     ##
     # Adds an Database. Multiple Databases may be added to the model.
     def database(name, database_id = nil, &block)
+      dsl_name = dsl_const_name(name)
+      if deprecated_module? dsl_name
+        Logger.warn "The Backup database \"#{dsl_name}\" is " \
+          "scheduled to be deprecated. If you're using this feature, " \
+          "please see: https://github.com/backup/backup/issues/851"
+      end
       @databases << get_class_from_scope(Database, name)
         .new(self, database_id, &block)
     end
@@ -147,6 +165,12 @@ module Backup
     ##
     # Adds an Storage. Multiple Storages may be added to the model.
     def store_with(name, storage_id = nil, &block)
+      dsl_name = dsl_const_name(name)
+      if deprecated_module? dsl_name
+        Logger.warn "The Backup storage \"#{dsl_name}\" is " \
+          "scheduled to be deprecated. If you're using this feature, " \
+          "please see: https://github.com/backup/backup/issues/851"
+      end
       @storages << get_class_from_scope(Storage, name)
         .new(self, storage_id, &block)
     end
@@ -154,12 +178,22 @@ module Backup
     ##
     # Adds an Syncer. Multiple Syncers may be added to the model.
     def sync_with(name, syncer_id = nil, &block)
+      dsl_name = dsl_const_name(name)
+      Logger.warn "The Backup syncer \"#{dsl_name}\" is " \
+        "scheduled to be deprecated. If you're using this feature, " \
+        "please see: https://github.com/backup/backup/issues/851"
       @syncers << get_class_from_scope(Syncer, name).new(syncer_id, &block)
     end
 
     ##
     # Adds an Notifier. Multiple Notifiers may be added to the model.
     def notify_by(name, &block)
+      dsl_name = dsl_const_name(name)
+      if deprecated_module? dsl_name
+        Logger.warn "The Backup notifier \"#{dsl_name}\" is " \
+          "scheduled to be deprecated. If you're using this feature, " \
+          "please see: https://github.com/backup/backup/issues/851"
+      end
       @notifiers << get_class_from_scope(Notifier, name).new(self, &block)
     end
 
@@ -290,6 +324,14 @@ module Backup
     end
 
     private
+
+    def dsl_const_name(name)
+      name.to_s.sub "Backup::Config::DSL::", ""
+    end
+
+    def deprecated_module?(name)
+      DEPRECATED_MODULES.include? name
+    end
 
     ##
     # Returns an array of procedures that will be performed if any

--- a/lib/backup/utilities.rb
+++ b/lib/backup/utilities.rb
@@ -149,6 +149,10 @@ module Backup
         command.shift while command[0].to_s.include?("=")
         parts << command.shift.split("/")[-1]
         if parts[0] == "sudo"
+          Logger.warn "The Backup option \"sudo\" is " \
+            "scheduled to be deprecated. If you're using this feature, " \
+            "please see: https://github.com/backup/backup/issues/851"
+
           until command.empty?
             part = command.shift
             if part.include?("/")


### PR DESCRIPTION
Deprecates Databases, syncers, storage and notifiers as listed in #851.

Example output:

```
[2017/04/23 14:20:59][warn] The Backup database "OpenLDAP" is scheduled to be deprecated. If you're using this feature, please see: https://github.com/backup/backup/issues/851
[2017/04/23 14:20:59][warn] The Backup syncer "Cloud::CloudFiles" is scheduled to be deprecated. If you're using this feature, please see: https://github.com/backup/backup/issues/851
```

Closes #851