### PR TITLE
Fix CLI option types 

### DIFF
--- a/lib/backup/cli.rb
+++ b/lib/backup/cli.rb
@@ -87,19 +87,19 @@ module Backup
     # so the --no-<option> usage will set the value to nil instead of false.
     method_option :quiet,
       aliases: "-q",
-      type: :string,
+      type: :boolean,
       default: false,
       banner: "",
       desc: "Disable console log output."
 
     method_option :syslog,
-      type: :string,
+      type: :boolean,
       default: false,
       banner: "",
       desc: "Enable logging to syslog."
 
     method_option :logfile,
-      type: :string,
+      type: :boolean,
       default: true,
       banner: "",
       desc: "Enable Backup's log file."

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -33,25 +33,23 @@ describe "Backup::CLI" do
           cli.start
         end.not_to raise_error
 
-        expect(logger_options.console.quiet).to be(false)
+        expect(logger_options.console.quiet).to eq(false)
         expect(logger_options.logfile.enabled).to eq(true)
         expect(logger_options.logfile.log_path).to eq("")
-        expect(logger_options.syslog.enabled).to be(false)
+        expect(logger_options.syslog.enabled).to eq(false)
       end
 
       it "configures only the syslog" do
-        expect do
-          ARGV.replace(
-            ["perform", "-t", "test_trigger_a,test_trigger_b",
-             "--quiet", "--no-logfile", "--syslog"]
-          )
-          cli.start
-        end.not_to raise_error
+        ARGV.replace(
+          ["perform", "-t", "test_trigger_a,test_trigger_b",
+           "--quiet", "--no-logfile", "--syslog"]
+        )
+        cli.start
 
-        expect(logger_options.console.quiet).to be_truthy
-        expect(logger_options.logfile.enabled).to be_nil
+        expect(logger_options.console.quiet).to eq(true)
+        expect(logger_options.logfile.enabled).to eq(false)
         expect(logger_options.logfile.log_path).to eq("")
-        expect(logger_options.syslog.enabled).to be_truthy
+        expect(logger_options.syslog.enabled).to eq(true)
       end
 
       it "forces console logging" do
@@ -62,10 +60,10 @@ describe "Backup::CLI" do
           cli.start
         end.not_to raise_error
 
-        expect(logger_options.console.quiet).to be_nil
+        expect(logger_options.console.quiet).to eq(false)
         expect(logger_options.logfile.enabled).to eq(true)
         expect(logger_options.logfile.log_path).to eq("")
-        expect(logger_options.syslog.enabled).to be(false)
+        expect(logger_options.syslog.enabled).to eq(false)
       end
 
       it "forces the logfile and syslog to be disabled" do
@@ -77,10 +75,10 @@ describe "Backup::CLI" do
           cli.start
         end.not_to raise_error
 
-        expect(logger_options.console.quiet).to be(false)
-        expect(logger_options.logfile.enabled).to be_nil
+        expect(logger_options.console.quiet).to eq(false)
+        expect(logger_options.logfile.enabled).to eq(false)
         expect(logger_options.logfile.log_path).to eq("")
-        expect(logger_options.syslog.enabled).to be_nil
+        expect(logger_options.syslog.enabled).to eq(false)
       end
 
       it "configures the log_path" do
@@ -92,10 +90,10 @@ describe "Backup::CLI" do
           cli.start
         end.not_to raise_error
 
-        expect(logger_options.console.quiet).to be(false)
+        expect(logger_options.console.quiet).to eq(false)
         expect(logger_options.logfile.enabled).to eq(true)
         expect(logger_options.logfile.log_path).to eq("my/log/path")
-        expect(logger_options.syslog.enabled).to be(false)
+        expect(logger_options.syslog.enabled).to eq(false)
       end
     end # describe 'setting logger options'
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -28,10 +28,8 @@ describe "Backup::CLI" do
       end
 
       it "configures console and logfile loggers by default" do
-        expect do
-          ARGV.replace(["perform", "-t", "test_trigger_a,test_trigger_b"])
-          cli.start
-        end.not_to raise_error
+        ARGV.replace(["perform", "-t", "test_trigger_a,test_trigger_b"])
+        cli.start
 
         expect(logger_options.console.quiet).to eq(false)
         expect(logger_options.logfile.enabled).to eq(true)
@@ -53,12 +51,10 @@ describe "Backup::CLI" do
       end
 
       it "forces console logging" do
-        expect do
-          ARGV.replace(
-            ["perform", "-t", "test_trigger_a,test_trigger_b", "--no-quiet"]
-          )
-          cli.start
-        end.not_to raise_error
+        ARGV.replace(
+          ["perform", "-t", "test_trigger_a,test_trigger_b", "--no-quiet"]
+        )
+        cli.start
 
         expect(logger_options.console.quiet).to eq(false)
         expect(logger_options.logfile.enabled).to eq(true)
@@ -67,13 +63,11 @@ describe "Backup::CLI" do
       end
 
       it "forces the logfile and syslog to be disabled" do
-        expect do
-          ARGV.replace(
-            ["perform", "-t", "test_trigger_a,test_trigger_b",
-             "--no-logfile", "--no-syslog"]
-          )
-          cli.start
-        end.not_to raise_error
+        ARGV.replace(
+          ["perform", "-t", "test_trigger_a,test_trigger_b",
+           "--no-logfile", "--no-syslog"]
+        )
+        cli.start
 
         expect(logger_options.console.quiet).to eq(false)
         expect(logger_options.logfile.enabled).to eq(false)
@@ -82,13 +76,11 @@ describe "Backup::CLI" do
       end
 
       it "configures the log_path" do
-        expect do
-          ARGV.replace(
-            ["perform", "-t", "test_trigger_a,test_trigger_b",
-             "--log-path", "my/log/path"]
-          )
-          cli.start
-        end.not_to raise_error
+        ARGV.replace(
+          ["perform", "-t", "test_trigger_a,test_trigger_b",
+           "--log-path", "my/log/path"]
+        )
+        cli.start
 
         expect(logger_options.console.quiet).to eq(false)
         expect(logger_options.logfile.enabled).to eq(true)
@@ -111,12 +103,10 @@ describe "Backup::CLI" do
         Backup::Logger.expects(:clear!).in_sequence(s)
         model_b.expects(:perform!).never
 
-        expect do
-          ARGV.replace(
-            ["perform", "-t", "test_trigger_a"]
-          )
-          cli.start
-        end.not_to raise_error
+        ARGV.replace(
+          ["perform", "-t", "test_trigger_a"]
+        )
+        cli.start
       end
 
       it "performs multiple triggers" do
@@ -125,12 +115,10 @@ describe "Backup::CLI" do
         model_b.expects(:perform!).in_sequence(s)
         Backup::Logger.expects(:clear!).in_sequence(s)
 
-        expect do
-          ARGV.replace(
-            ["perform", "-t", "test_trigger_a,test_trigger_b"]
-          )
-          cli.start
-        end.not_to raise_error
+        ARGV.replace(
+          ["perform", "-t", "test_trigger_a,test_trigger_b"]
+        )
+        cli.start
       end
 
       it "performs multiple models that share a trigger name" do
@@ -141,12 +129,10 @@ describe "Backup::CLI" do
         model_d.expects(:perform!).in_sequence(s)
         Backup::Logger.expects(:clear!).in_sequence(s)
 
-        expect do
-          ARGV.replace(
-            ["perform", "-t", "test_trigger_c"]
-          )
-          cli.start
-        end.not_to raise_error
+        ARGV.replace(
+          ["perform", "-t", "test_trigger_c"]
+        )
+        cli.start
       end
 
       it "performs unique models only once, in the order first found" do
@@ -157,12 +143,10 @@ describe "Backup::CLI" do
         model_c.expects(:perform!).in_sequence(s)
         Backup::Logger.expects(:clear!).in_sequence(s)
 
-        expect do
-          ARGV.replace(
-            ["perform", "-t", "test_trigger_a,test_trigger_b,test_trigger_c,test_trigger_b"]
-          )
-          cli.start
-        end.not_to raise_error
+        ARGV.replace(
+          ["perform", "-t", "test_trigger_a,test_trigger_b,test_trigger_c,test_trigger_b"]
+        )
+        cli.start
       end
 
       it "performs unique models only once, in the order first found (wildcard)" do
@@ -173,12 +157,10 @@ describe "Backup::CLI" do
         model_c.expects(:perform!).in_sequence(s)
         Backup::Logger.expects(:clear!).in_sequence(s)
 
-        expect do
-          ARGV.replace(
-            ["perform", "-t", "test_trigger_*"]
-          )
-          cli.start
-        end.not_to raise_error
+        ARGV.replace(
+          ["perform", "-t", "test_trigger_*"]
+        )
+        cli.start
       end
     end # describe 'setting triggers'
 


### PR DESCRIPTION
Thor upgrade that checks for option types outputted the following:

```
Expected string default value for '--quiet'; got false (boolean)
Expected string default value for '--syslog'; got false (boolean)
Expected string default value for '--logfile'; got true (boolean)
```

Changed these option types to boolean from string, as the default value
was a boolean and the warnings disappear.