### PR TITLE
Docker for testing (second version)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+.travis.yml
+docker-compose.yml
+vagrant

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.1
+FROM ruby:2.4.2
 
 ## 1. Image metadata ##
  LABEL maintainer="stuart@stuartellis.name" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM ruby:2.4.1
+
+## 1. Image metadata ##
+
+MAINTAINER Tom de Bruijn, tom@tomdebruijn.com
+LABEL version="0.1.0" \
+    description="Image for running the backup Rubygem"
+
+## 2. Add operating system packages ##
+
+# Dependencies for developing and running Backup
+#  * The Nokogiri gem requires libxml2
+#  * The unf_ext gem requires the g++ compiler to build
+ENV APP_DEPS bsdtar ca-certificates curl g++ git \
+    libxml2 libxslt1.1 libyaml-0-2 openssl
+
+RUN apt-get update && apt-get install -y --no-install-recommends $APP_DEPS
+
+## 3. Set working directory ##
+
+ENV APP_HOME /usr/src/backup
+WORKDIR $APP_HOME
+
+## 4. Add Ruby gem packages ##
+
+COPY lib/backup/version.rb $APP_HOME/lib/backup/
+COPY backup.gemspec Gemfile* $APP_HOME/
+RUN bundle config build.nokogiri --use-system-libraries && bundle install && \
+    rm -r $APP_HOME/lib/backup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM ruby:2.4.1
 
 ## 1. Image metadata ##
-
-MAINTAINER Tom de Bruijn, tom@tomdebruijn.com
-LABEL version="0.1.0" \
+ LABEL maintainer="stuart@stuartellis.name" \
+    version="0.1.0" \
     description="Image for running the backup Rubygem"
 
 ## 2. Add operating system packages ##

--- a/Rakefile
+++ b/Rakefile
@@ -117,7 +117,7 @@ namespace :docker do
   task shell: [:build] do
     sh "docker-compose run -e RUBYPATH='/usr/local/bundle/bin:/usr/local/bin' " \
          "-v $PWD:/usr/src/backup ruby_backup_tester /bin/bash"
-    end
+  end
   desc "Run RSpec unit tests with Docker Compose"
   task spec: [:build] do
     sh "docker-compose run ruby_backup_tester " \

--- a/Rakefile
+++ b/Rakefile
@@ -80,3 +80,15 @@ task :release do
 
   puts "Backup version #{new_version} released!"
 end
+
+namespace :docker do
+  desc "Build testing containers with Docker Compose"
+  task :build do
+    sh "docker-compose build"
+  end
+  desc "Run RSpec tests with Docker Compose"
+  task spec: [:build] do
+    sh "docker-compose run ruby_backup_tester " \
+       "ruby -Ilib -S rspec ./spec/"
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,10 @@
+require "rake/clean"
+
+CLEAN.include("tmp")
+CLOBBER.include("tmp")
+
+Dir["integration/tasks/**/*.rake"].each { |f| import f }
+
 require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
@@ -86,7 +93,12 @@ namespace :docker do
   task :build do
     sh "docker-compose build"
   end
-  desc "Run RSpec tests with Docker Compose"
+  desc "Run RSpec integration tests with Docker Compose"
+  task integration: ["build", "integration:files"] do
+    sh "docker-compose run ruby_backup_tester " \
+       "ruby -Ilib -S rspec ./integration/acceptance/"
+  end
+  desc "Run RSpec unit tests with Docker Compose"
   task spec: [:build] do
     sh "docker-compose run ruby_backup_tester " \
        "ruby -Ilib -S rspec ./spec/"

--- a/Rakefile
+++ b/Rakefile
@@ -109,17 +109,17 @@ namespace :docker do
     `docker rmi #{images}` unless images.empty?
   end
   desc "Run RSpec integration tests with Docker Compose"
-  task integration: ["build", "integration:files"] do
+  task integration: ["integration:files"] do
     sh "docker-compose run ruby_backup_tester " \
        "ruby -Ilib -S rspec ./integration/acceptance/"
   end
   desc "Start a container environment with an interactive shell"
-  task shell: [:build] do
+  task :shell do
     sh "docker-compose run -e RUBYPATH='/usr/local/bundle/bin:/usr/local/bin' " \
          "-v $PWD:/usr/src/backup ruby_backup_tester /bin/bash"
   end
   desc "Run RSpec unit tests with Docker Compose"
-  task spec: [:build] do
+  task :spec do
     sh "docker-compose run ruby_backup_tester " \
        "ruby -Ilib -S rspec ./spec/"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -93,11 +93,31 @@ namespace :docker do
   task :build do
     sh "docker-compose build"
   end
+  desc "Remove Docker containers for Backup"
+  task :clean do
+    containers = `docker ps -a | grep 'ruby_backup_*' | awk '{ print $1 }'`
+      .tr("\n", " ")
+    unless containers.empty?
+      `docker stop #{containers}`
+      `docker rm #{containers}`
+    end
+  end
+  desc "Remove Docker containers and images for Backup"
+  task clobber: [:clean] do
+    images = `docker images | grep 'ruby_backup_*' | awk '{ print $3 }'`
+      .tr("\n", " ")
+    `docker rmi #{images}` unless images.empty?
+  end
   desc "Run RSpec integration tests with Docker Compose"
   task integration: ["build", "integration:files"] do
     sh "docker-compose run ruby_backup_tester " \
        "ruby -Ilib -S rspec ./integration/acceptance/"
   end
+  desc "Start a container environment with an interactive shell"
+  task shell: [:build] do
+    sh "docker-compose run -e RUBYPATH='/usr/local/bundle/bin:/usr/local/bin' " \
+         "-v $PWD:/usr/src/backup ruby_backup_tester /bin/bash"
+    end
   desc "Run RSpec unit tests with Docker Compose"
   task spec: [:build] do
     sh "docker-compose run ruby_backup_tester " \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+  ruby_backup_tester:
+    build: .
+    command: /bin/bash
+    image: ruby_backup_tester
+    volumes:
+      - ".:/usr/src/backup"

--- a/integration/acceptance/archive_spec.rb
+++ b/integration/acceptance/archive_spec.rb
@@ -1,0 +1,40 @@
+# encoding: utf-8
+
+require File.expand_path("../../spec_helper", __FILE__)
+
+module Backup
+  describe Archive do
+    specify "All directories, no compression, without :root" do
+      create_model :my_backup, <<-EOS
+        Backup::Model.new(:my_backup, 'a description') do
+          archive :archive_a do |archive|
+            archive.add "./tmp/test_data"
+          end
+          store_with Local
+        end
+      EOS
+
+      job = backup_perform :my_backup
+
+      expect(job.package.exist?).to be true
+
+      expect(job.package).to match_manifest(<<-EOS)
+        10_496_000 my_backup/archives/archive_a.tar
+      EOS
+
+      package_a = job.package["my_backup/archives/archive_a.tar"]
+      expect(package_a).to match_manifest(<<-EOS)
+        1_048_576 /usr/src/backup/tmp/test_data/dir_a/1.txt
+        1_048_576 /usr/src/backup/tmp/test_data/dir_a/2.txt
+        1_048_576 /usr/src/backup/tmp/test_data/dir_a/3.txt
+        1_048_576 /usr/src/backup/tmp/test_data/dir_b/1.txt
+        1_048_576 /usr/src/backup/tmp/test_data/dir_b/2.txt
+        1_048_576 /usr/src/backup/tmp/test_data/dir_b/3.txt
+        1_048_576 /usr/src/backup/tmp/test_data/dir_c/1.txt
+        1_048_576 /usr/src/backup/tmp/test_data/dir_c/2.txt
+        1_048_576 /usr/src/backup/tmp/test_data/dir_c/3.txt
+        1_048_576 /usr/src/backup/tmp/test_data/dir_d/1.txt
+      EOS
+    end
+  end
+end

--- a/integration/spec_helper.rb
+++ b/integration/spec_helper.rb
@@ -1,0 +1,9 @@
+# encoding: utf-8
+
+require "backup"
+
+Dir[File.expand_path("../support/**/*.rb", __FILE__)].each { |f| require f }
+
+RSpec.configure do |c|
+  c.include BackupSpec::ExampleHelpers
+end

--- a/integration/support/example_helpers.rb
+++ b/integration/support/example_helpers.rb
@@ -1,0 +1,135 @@
+# encoding: utf-8
+
+module BackupSpec
+  CONFIG_TEMPLATE = Backup::Template.new.result("cli/config")
+  PROJECT_ROOT = "/usr/src/backup".freeze
+  LOCAL_STORAGE_PATH = File.join(PROJECT_ROOT, "tmp", "Storage")
+
+  module ExampleHelpers
+    # Creates the config.rb file.
+    #
+    # By default, this will be created as ~/Backup/config.rb,
+    # since Backup::Config is reset before each example.
+    #
+    # If paths will be changed when calling backup_perform(),
+    # like --config-file or --root-path, then the full path to
+    # the config file must be given here in +config_file+.
+    #
+    # The config file created here will disable console log output
+    # and file logging, but this may be overridden in +text+.
+    #
+    # Note that the first line in +text+ will set the indent for the text being
+    # given and that indent will be removed from all lines in +text+
+    #
+    # If you don"t intend to change the default config.rb contents or path,
+    # you can omit this method from your example. Calling create_model()
+    # will call this method if the +config_file+ does not exist.
+    def create_config(text = nil, config_file = nil)
+      config_file ||= Backup::Config.config_file
+      config_path = File.dirname(config_file)
+
+      unless text.to_s.empty?
+        indent = text.lines.first.match(/^ */)[0].length
+        text = text.lines.map { |l| l[indent..-1] }.join
+      end
+      config = <<-EOS.gsub(/^        /, "")
+        # encoding: utf-8
+
+        Backup::Utilities.configure do
+          # silence the log output produced by the auto-detection
+          tar_dist :gnu
+        end
+
+        Backup::Logger.configure do
+          console.quiet = true
+          logfile.enabled = false
+        end
+
+        Backup::Storage::Local.defaults do |local|
+          local.path = "#{LOCAL_STORAGE_PATH}"
+        end
+
+        #{text}
+
+        #{CONFIG_TEMPLATE}
+      EOS
+
+      # Create models path, since models are always relative to the config file.
+      FileUtils.mkdir_p File.join(config_path, "models")
+      File.open(config_file, "w") { |f| f.write config }
+    end
+
+    # Creates a model file.
+    #
+    # Pass +config_file+ if it won"t be at the default path +~/Backup/+.
+    #
+    # Creates the model as +/models/<trigger>.rb+, relative to the path
+    # of +config_file+.
+    #
+    # Note that the first line in +text+ will set the indent for the text being
+    # given and that indent will be removed from all lines in +text+
+    def create_model(trigger, text, config_file = nil)
+      config_file ||= Backup::Config.config_file
+      model_path = File.join(File.dirname(config_file), "models")
+      model_file = File.join(model_path, trigger.to_s + ".rb")
+
+      create_config(nil, config_file) unless File.exist?(config_file)
+
+      indent = text.lines.first.match(/^ */)[0].length
+      text = text.lines.map { |l| l[indent..-1] }.join
+      config = <<-EOS.gsub(/^        /, "")
+        # encoding: utf-8
+
+        #{text}
+      EOS
+
+      File.open(model_file, "w") { |f| f.write config }
+    end
+
+    # Runs the given trigger(s).
+    #
+    # Any +options+ given are passed as command line options to the
+    # `backup perform` command. These should be given as String arguments.
+    # e.g. job = backup_perform :my_backup, "--tmp-path=/tmp"
+    #
+    # The last argument given for +options+ may be a Hash, which is used
+    # as options for this method. If { :exit_status => Integer } is set,
+    # this method will rescue SystemExit and assert that the exit status
+    # is correct. This allows jobs that log warnings to continue and return
+    # the performed job(s).
+    #
+    # When :focus is added to an example, "--no-quiet" will be appended to
+    # +options+ so you can see the log output as the backup is performed.
+    def backup_perform(triggers, *options)
+      triggers = Array(triggers).map(&:to_s)
+      opts = options.last.is_a?(Hash) ? options.pop : {}
+      exit_status = opts.delete(:exit_status)
+      argv = ["perform", "-t", triggers.join(",")] + options
+
+      # Reset config paths, utility paths and the logger.
+      Backup::Config.send(:reset!)
+      Backup::Utilities.send(:reset!)
+      Backup::Logger.send(:reset!)
+      # Ensure multiple runs have different timestamps
+      sleep 1 unless Backup::Model.all.empty?
+      # Clear previously loaded models and other class instance variables
+      Backup::Model.send(:reset!)
+
+      ARGV.replace(argv)
+
+      if exit_status
+        expect do
+          Backup::CLI.start
+        end.to raise_error(SystemExit) { |exit|
+          expect(exit.status).to be(exit_status)
+        }
+      else
+        Backup::CLI.start
+      end
+
+      models = triggers.map { |t| Backup::Model.find_by_trigger(t).first }
+      jobs = models.map { |m| BackupSpec::PerformedJob.new(m) }
+      jobs.count > 1 ? jobs : jobs.first
+    end
+  end
+end

--- a/integration/support/logger.rb
+++ b/integration/support/logger.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+
+module Backup
+  class Logger
+    class << self
+      alias _clear! clear!
+      def clear!
+        saved << logger
+        _clear!
+      end
+
+      def saved
+        @saved ||= []
+      end
+
+      private
+
+      alias _reset! reset!
+      def reset!
+        @saved = nil
+        _reset!
+      end
+    end
+  end
+end

--- a/integration/support/match_manifest.rb
+++ b/integration/support/match_manifest.rb
@@ -1,0 +1,69 @@
+# encoding: utf-8
+
+# Matches the contents of a TarFile (or PerformedJob.package)
+# against the given manifest.
+#
+# Usage:
+#
+#     performed_job = backup_perform :trigger
+#
+#     expect(performed_job.package).to match_manifest(<<-EOS)
+#       51200  my_backup/archives/my_archive.tar
+#       8099   my_backup/databases/MySQL/backup_test_01.sql
+#     EOS
+#
+# File sizes may also be tested against a range, using `min..max`.
+#
+#     expect(performed_job.package).to match_manifest(%q[
+#       51200..51250 my_backup/archives/my_archive.tar
+#       8099         my_backup/databases/MySQL/backup_test_01.sql
+#     ])
+#
+# Or simply checked for existance, using `-`:
+#
+#     expect(performed_job.package).to match_manifest(%q[
+#       -     my_backup/archives/my_archive.tar
+#       8099  my_backup/databases/MySQL/backup_test_01.sql
+#     ])
+#
+# Extra spaces and blank lines are ok.
+#
+# If the given files with the given sizes do not match all the files
+# in the archive"s manifest, the error message will include the entire
+# manifest as output by `tar -tvf`.
+RSpec::Matchers.define :match_manifest do |expected|
+  match do |actual|
+    expected_contents = expected.split("\n").map(&:strip).reject(&:empty?)
+    expected_contents.map! { |line| line.split(" ") }
+    expected_contents = Hash[
+      expected_contents.map { |fields| [fields[1], fields[0]] }
+    ]
+
+    files_match = expected_contents.keys.sort == actual.contents.keys.sort
+    if files_match
+      sizes_ok = true
+      expected_contents.each do |path, size|
+        actual_size = actual.contents[path]
+
+        sizes_ok =
+          case size
+          when "-" then true
+          when /\d+(\.\.)\d+/
+            a, b = size.split("..").map(&:to_i)
+            (a..b).cover? actual_size
+          else
+            size.to_i == actual_size
+          end
+
+        break unless sizes_ok
+      end
+    end
+
+    files_match && sizes_ok
+  end
+
+  failure_message do |actual|
+    "expected that:\n\n#{actual.manifest}\n" \
+    "would match:\n#{expected}"
+  end
+end

--- a/integration/support/package.rb
+++ b/integration/support/package.rb
@@ -1,0 +1,76 @@
+# encoding: utf-8
+
+module BackupSpec
+  class Package
+    include Backup::Utilities::Helpers
+    extend Forwardable
+    def_delegators :tarfile, :manifest, :contents, :[]
+
+    attr_reader :model
+
+    def initialize(model)
+      @model = model
+    end
+
+    def exist?
+      !files.empty? && files.all? { |f| File.exist?(f) }
+    end
+
+    def path
+      @path ||= unsplit
+    end
+
+    # Note that once the package is inspected with the match_manifest matcher,
+    # a Tarfile will be created. If the Splitter was used, this will create an
+    # additional file (the re-joined tar) in the remote_path. If #[] is used,
+    # the package will be extracted into the remote_path. Some cycling
+    # operations remove each package file, then the timestamp directory which
+    # should be empty at that point. So you can"t inspect a split package"s
+    # manifest or inspect tar files within the package when testing cycling.
+    def removed?
+      files.all? { |f| !File.exist?(f) }
+    end
+
+    # If a trigger is run multiple times within a test (like when testing cycling),
+    # multiple packages will exist under different timestamp folders.
+    # This allows us to find the package files for the specific model given.
+    #
+    # For most tests the Local storage is used, which will have a remote_path
+    # that"s already expanded. Others like SCP, RSync (:ssh mode), etc... will
+    # have a remote_path that"s relative to the vagrant user"s home.
+    # The exception is the RSync daemon modes, where remote_path will begin
+    # with daemon module names, which are mapped to the vagrant user"s home.
+    def files
+      @files ||= begin
+        storage = model.storages.first
+        return [] unless storage # model didn"t store anything
+
+        path = storage.send(:remote_path)
+        unless path == File.expand_path(path)
+          path.sub!(/(ssh|rsync)-daemon-module/, "")
+          path = File.expand_path(File.join("tmp", path))
+        end
+        Dir[File.join(path, "#{model.trigger}.tar*")].sort
+      end
+    end
+
+    private
+
+    def tarfile
+      @tarfile ||= TarFile.new(path)
+    end
+
+    def unsplit
+      return files.first unless files.count > 1
+
+      base_dir = File.dirname(files.first)
+      orig_ext = File.extname(files.first)
+      base_ext = orig_ext.split("-").first
+      outfile = File.basename(files.first).sub(/#{ orig_ext }$/, base_ext)
+      Dir.chdir(base_dir) do
+        `#{ utility(:cat) } #{ outfile }-* > #{ outfile }`
+      end
+      File.join(base_dir, outfile)
+    end
+  end
+end

--- a/integration/support/performed_job.rb
+++ b/integration/support/performed_job.rb
@@ -1,0 +1,12 @@
+# encoding: utf-8
+
+module BackupSpec
+  class PerformedJob
+    attr_reader :model, :logger, :package
+    def initialize(model)
+      @model = model
+      @logger = Backup::Logger.saved.shift
+      @package = Package.new(model)
+    end
+  end
+end

--- a/integration/support/tarfile.rb
+++ b/integration/support/tarfile.rb
@@ -1,0 +1,66 @@
+# encoding: utf-8
+
+module BackupSpec
+  class TarFile
+    include Backup::Utilities::Helpers
+
+    attr_reader :path
+
+    def initialize(path)
+      @path = path
+    end
+
+    def manifest
+      @manifest ||= begin
+        if File.exist?(path.to_s)
+          `#{ utility(:tar) } -tvf #{ path } 2>/dev/null`
+        else
+          ""
+        end
+      end
+    end
+
+    # GNU/BSD have different formats for `tar -tvf`.
+    #
+    # Returns a Hash of { "path" => size } for only the files in the manifest.
+    def contents
+      @contents ||= begin
+        data = manifest.split("\n").reject { |line| line =~ %r{\/$} }
+        data.map! { |line| line.split(" ") }
+        if gnu_tar?
+          Hash[data.map { |fields| [fields[5], fields[2].to_i] }]
+        else
+          Hash[data.map { |fields| [fields[8], fields[4].to_i] }]
+        end
+      end
+    end
+
+    def [](val)
+      extracted_files[val]
+    end
+
+    private
+
+    # Return a Hash with the paths from #contents mapped to either another
+    # TarFile object (for tar files) or the full path to the extracted file.
+    def extracted_files
+      @extracted_files ||= begin
+        base_path = File.dirname(path)
+        filename = File.basename(path)
+        Dir.chdir(base_path) do
+          `#{ utility(:tar) } -xf #{ filename } 2>/dev/null`
+        end
+        Hash[
+          contents.keys.map do |manifest_path|
+            path = File.join(base_path, manifest_path.sub(%r{^\/}, ""))
+            if path =~ /\.tar.*$/
+              [manifest_path, self.class.new(path)]
+            else
+              [manifest_path, path]
+            end
+          end
+        ]
+      end
+    end
+  end
+end

--- a/integration/tasks/files.rake
+++ b/integration/tasks/files.rake
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+require File.expand_path("../fileset_builder", __FILE__)
+
+directory "tmp"
+directory "tmp/test_data"
+
+namespace :integration do
+  desc "Create test files"
+  task files: ["tmp", "tmp/test_data"] do
+    fb = FilesetBuilder.new
+    test_dirs = { "dir_a" => 3, "dir_b" => 3, "dir_c" => 3, "dir_d" => 1 }
+    test_dirs.each do |dir, total|
+      fb.create(File.join("tmp", "test_data"), dir, total, 1)
+    end
+  end
+end

--- a/integration/tasks/fileset_builder.rb
+++ b/integration/tasks/fileset_builder.rb
@@ -1,0 +1,30 @@
+# encoding: utf-8
+
+class FilesetBuilder
+  def create(root_dir, dir_name, total, file_size)
+    create_dir(root_dir, dir_name)
+    create_fileset(File.join(root_dir, dir_name), total, file_size)
+  end
+
+  def create_dir(parent_dir, dir_name)
+    dir = File.join(parent_dir, dir_name)
+    Dir.mkdir(dir) unless Dir.exist?(dir)
+  end
+
+  def create_file(file_path, file_size)
+    File.open(file_path, "w") do |file|
+      contents = "x" * (1024 * 1024)
+      file_size.to_i.times { file.write(contents) }
+    end
+  end
+
+  def create_fileset(dir, total, file_size)
+    count = 0
+    total.times do
+      count += 1
+      file_name = "#{count}.txt"
+      file_path = File.join(dir, file_name)
+      create_file(file_path, file_size)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds Docker support for testing. It supersedes PR #832.

The first commit adds Docker, and a Rake task for running the RSpec unit tests inside the container.

The second commit enables integration tests to run inside the container, adds the supporting code for testing generated backup archives, and provides one integration test (in integration/acceptance/archive_spec.rb).