### PR TITLE
Bump `mail` and `nokogiri` dependencies for security updates

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-ssh", "3.2.0"
   gem.add_dependency "net-scp", "1.2.1"
   gem.add_dependency "net-sftp", "2.1.2"
-  gem.add_dependency "mail", "2.6.5" # patched
+  gem.add_dependency "mail", "~> 2.6", ">= 2.6.6"
   gem.add_dependency "pagerduty", "2.0.0"
   gem.add_dependency "twitter", "~> 5.5"
   gem.add_dependency "hipchat", "1.0.1"
@@ -44,7 +44,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "dogapi", "1.11.0"
   gem.add_dependency "aws-sdk", "~> 2"
   gem.add_dependency "qiniu", "~> 6.5"
-  gem.add_dependency "nokogiri", "~> 1.7", ">= 1.7.1"
+  gem.add_dependency "nokogiri", "~> 1.7", ">= 1.7.2"
 
   gem.add_development_dependency "rubocop", "0.48.1"
   gem.add_development_dependency "rake"

--- a/lib/backup/notifier/mail.rb
+++ b/lib/backup/notifier/mail.rb
@@ -230,17 +230,3 @@ module Backup
     end
   end
 end
-
-# Patch mail v2.5.4 Exim delivery method
-# https://github.com/backup/backup/issues/446
-# https://github.com/mikel/mail/pull/546
-module Mail
-  class Exim
-    def self.call(path, arguments, _destinations, encoded_message)
-      popen "#{path} #{arguments}" do |io|
-        io.puts ::Mail::Utilities.to_lf(encoded_message)
-        io.flush
-      end
-    end
-  end
-end


### PR DESCRIPTION
`mail` v2.6.6 -- https://github.com/mikel/mail/releases/tag/2.6.6
`nokogiri` v1.7.2 -- https://github.com/sparklemotion/nokogiri/blob/v1.7.2/CHANGELOG.md#172--2017-05-09

The `mail` patch for Exim SMTP support is [no longer required](https://github.com/mikel/mail/commit/67ac9bb7128c3e3f74ee4f8e7115a00727652876) as well.