### PR TITLE
Upgrade dogapi dependency to get ruby 2.4-compatible json gem

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "twitter", "~> 5.5"
   gem.add_dependency "hipchat", "1.0.1"
   gem.add_dependency "flowdock", "0.4.0"
-  gem.add_dependency "dogapi", "1.11.0"
+  gem.add_dependency "dogapi", "1.27.0"
   gem.add_dependency "aws-sdk", "~> 2"
   gem.add_dependency "qiniu", "~> 6.5"
   gem.add_dependency "nokogiri", "~> 1.7", ">= 1.7.2"


### PR DESCRIPTION
The gem doesn't currently install under ruby v2.4 - it fails due to dogapi's dependency on an old version of the JSON gem (see https://github.com/flori/json/issues/303):

```
An error occurred while installing json (1.8.2), and Bundler cannot continue.
Make sure that `gem install json -v '1.8.2'` succeeds before bundling.

In Gemfile:
  backup was resolved to 4.4.0, which depends on
    dogapi was resolved to 1.11.0, which depends on
      json
```

Requiring a newer version of `dogapi` fixes this.

This seems similar to https://github.com/backup/backup/pull/830