### PR TITLE
Don't store project files on docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *.gem
 *.log
+.bundle
 .git
 .github
 .gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,9 @@
+*.gem
+*.log
 .git
+.github
 .gitignore
 .travis.yml
 docker-compose.yml
+tmp
 vagrant

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,3 @@ RUN apt-get update && apt-get install -y --no-install-recommends $APP_DEPS
 
 ENV APP_HOME /usr/src/backup
 WORKDIR $APP_HOME
-
-## 4. Add Ruby gem packages ##
-
-COPY lib/backup/version.rb $APP_HOME/lib/backup/
-COPY backup.gemspec Gemfile* $APP_HOME/
-RUN bundle config build.nokogiri --use-system-libraries && bundle install && \
-    rm -r $APP_HOME/lib/backup

--- a/Rakefile
+++ b/Rakefile
@@ -93,9 +93,13 @@ namespace :docker do
   task :build do
     sh "docker-compose build"
   end
+  desc "Prepare the bundle on the Docker machine"
+  task prepare: ["docker:build"] do
+    run_in_docker_container "bin/docker_test prepare"
+  end
   desc "Remove Docker containers for Backup"
   task :clean do
-    containers = `docker ps -a | grep 'ruby_backup_*' | awk '{ print $1 }'`
+    containers = `docker ps -a | grep 'backup/test-suite:local' | awk '{ print $1 }'`
       .tr("\n", " ")
     unless containers.empty?
       `docker stop #{containers}`
@@ -104,7 +108,7 @@ namespace :docker do
   end
   desc "Remove Docker containers and images for Backup"
   task clobber: [:clean] do
-    images = `docker images | grep 'ruby_backup_*' | awk '{ print $3 }'`
+    images = `docker images | grep 'backup/test-suite:local' | awk '{ print $3 }'`
       .tr("\n", " ")
     `docker rmi #{images}` unless images.empty?
   end

--- a/Rakefile
+++ b/Rakefile
@@ -98,7 +98,7 @@ namespace :docker do
   end
   desc "Remove Docker containers and images for Backup"
   task :clobber do
-    images = `docker images | grep 'backup/test-suite:local' | awk '{ print $3 }'`
+    images = `docker images | grep 'backup/test-suite' | awk '{ print $3 }'`
       .tr("\n", " ")
     `docker rmi #{images}` unless images.empty?
   end

--- a/Rakefile
+++ b/Rakefile
@@ -96,17 +96,8 @@ namespace :docker do
   task prepare: ["docker:build"] do
     run_in_docker_container "bin/docker_test prepare"
   end
-  desc "Remove Docker containers for Backup"
-  task :clean do
-    containers = `docker ps -a | grep 'backup/test-suite:local' | awk '{ print $1 }'`
-      .tr("\n", " ")
-    unless containers.empty?
-      `docker stop #{containers}`
-      `docker rm #{containers}`
-    end
-  end
   desc "Remove Docker containers and images for Backup"
-  task clobber: [:clean] do
+  task :clobber do
     images = `docker images | grep 'backup/test-suite:local' | awk '{ print $3 }'`
       .tr("\n", " ")
     `docker rmi #{images}` unless images.empty?

--- a/Rakefile
+++ b/Rakefile
@@ -89,7 +89,6 @@ task :release do
 end
 
 namespace :docker do
-  desc "Build testing containers with Docker Compose"
   task :build do
     sh "docker-compose build"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -109,18 +109,19 @@ namespace :docker do
     `docker rmi #{images}` unless images.empty?
   end
   desc "Run RSpec integration tests with Docker Compose"
-  task integration: ["integration:files"] do
-    sh "docker-compose run ruby_backup_tester " \
-       "ruby -Ilib -S rspec ./integration/acceptance/"
+  task integration: ["docker:build", "integration:files"] do
+    run_in_docker_container "bin/docker_test integration"
   end
   desc "Start a container environment with an interactive shell"
-  task :shell do
-    sh "docker-compose run -e RUBYPATH='/usr/local/bundle/bin:/usr/local/bin' " \
-         "-v $PWD:/usr/src/backup ruby_backup_tester /bin/bash"
+  task shell: ["docker:build"] do
+    run_in_docker_container "bin/docker_test console"
   end
   desc "Run RSpec unit tests with Docker Compose"
-  task :spec do
-    sh "docker-compose run ruby_backup_tester " \
-       "ruby -Ilib -S rspec ./spec/"
+  task spec: ["docker:build"] do
+    run_in_docker_container "bin/docker_test rspec"
+  end
+
+  def run_in_docker_container(command)
+    sh "docker-compose run --rm ruby_backup_tester #{command}"
   end
 end

--- a/bin/docker_test
+++ b/bin/docker_test
@@ -4,21 +4,17 @@ set -eu
 export BUNDLE_PATH=/tmp/docker/bundle
 export BUNDLE_JOBS=4
 
-prepare_bundle() {
-  bundle check || bundle install
-}
-
 case "${1-}" in
+prepare)
+  bundle check || bundle install
+  ;;
 rspec)
-  prepare_bundle
   bundle exec rspec spec
   ;;
 integration)
-  prepare_bundle
   bundle exec rspec integration/acceptance/
   ;;
 console)
-  prepare_bundle
   bash
   ;;
 *)

--- a/bin/docker_test
+++ b/bin/docker_test
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -eu
+
+export BUNDLE_PATH=/tmp/docker/bundle
+export BUNDLE_JOBS=4
+
+prepare_bundle() {
+  bundle check || bundle install
+}
+
+case "${1-}" in
+rspec)
+  prepare_bundle
+  bundle exec rspec spec
+  ;;
+integration)
+  prepare_bundle
+  bundle exec rspec integration/acceptance/
+  ;;
+console)
+  prepare_bundle
+  bash
+  ;;
+*)
+  echo "Task not found"
+  exit 1
+;;
+esac

--- a/bin/docker_test
+++ b/bin/docker_test
@@ -24,5 +24,5 @@ console)
 *)
   echo "Task not found"
   exit 1
-;;
+  ;;
 esac

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,5 @@ services:
     image: backup/test-suite:local
     working_dir: /usr/src/backup
     volumes:
-      - "./:/usr/src/backup"
-      - "./tmp/docker/:/tmp/docker"
+      - "./:/usr/src/backup:delegated"
+      - "./tmp/docker/:/tmp/docker:delegated"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   ruby_backup_tester:
     build: .
     command: /bin/bash
-    image: ruby_backup_tester
+    image: backup/test-suite:local
+    working_dir: /usr/src/backup
     volumes:
-      - ".:/usr/src/backup"
+      - "./:/usr/src/backup"
+      - "./tmp/docker/:/tmp/docker"


### PR DESCRIPTION
@stuartellis Great work on #857 ! Sorry I wasn't more active to review it.
I had a look and wondered why the image includes the bundle as that could introduce a stale state between the bundle on the image and the bundle of the project. Especially since it doesn't automatically build the image before running a command on a docker container.
To fix that I applied some of the setup I've recently setup for some other Docker testing projects.
Let me know if this sounds like a good idea to apply here too

Also wasn't sure why the `-I` and `-S` options were used for the Ruby scripts on the docker containers. Seems to work without it? If I missed some application of this, it might be nicer to move this setup to some of the files, so they're not reliant of the command that runs the test suites.

---

*commit message*:

This change only prepares the build environment on the docker image, but does
not create a production image which could be deployed for an app.

It uses volumes and a custom `BUNDLE_PATH` to store the gems in the
bundle which can be used between updates to the bundle itself. If a gem
version changes it would not have to reinstall all the gems and build
the image from that point, it would be able to reuse the bundler cache
(in the mounted volume) and only require an update to the changed gems.
Overal, should speed up the build process for the docker test
environment.

Added a `bin/docker_test` file that performs tasks within the docker
container.

Also made building the docker image mandatory when running the `docker`
namespaced rake files, so you can't end up with an out-of-sync state
where the docker image has changed, but hasn't been rebuild so a
developer would be testing against a stale image.