### PR TITLE
Update net-ssh

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "excon", "~> 0.44"
   gem.add_dependency "unf", "0.1.3" # for fog/AWS
   gem.add_dependency "dropbox-sdk", "1.6.5"
-  gem.add_dependency "net-ssh", "3.2.0"
+  gem.add_dependency "net-ssh", "4.2.0"
   gem.add_dependency "net-scp", "1.2.1"
   gem.add_dependency "net-sftp", "2.1.2"
   gem.add_dependency "mail", "~> 2.6", ">= 2.6.6"


### PR DESCRIPTION
### Background

I have some deprecation warnings using backup 5.0.0.beta2 with Ruby 2.4.2:

```
/usr/local/rvm/gems/ruby-2.4.2/gems/net-ssh-3.2.0/lib/net/ssh/transport/cipher_factory.rb:97: warning: constant OpenSSL::Cipher::Cipher is deprecated
/usr/local/rvm/gems/ruby-2.4.2/gems/net-ssh-3.2.0/lib/net/ssh/transport/cipher_factory.rb:72: warning: constant OpenSSL::Cipher::Cipher is deprecated
```

### Resolution

Updating net-ssh should fix this because beginning with version 4.0 it claims to have Ruby 2.4 support.

It still supports Ruby 2.0 and I do not see other braking changes compared to the old version.