### PR TITLE
Raise Ruby version for tests to 2.4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ruby:2.4.2
+FROM ruby:2.4.3
 
 ## 1. Image metadata ##
  LABEL maintainer="stuart@stuartellis.name" \
-    version="0.1.0" \
+    version="0.2.0" \
     description="Image for running the backup Rubygem"
 
 ## 2. Add operating system packages ##


### PR DESCRIPTION
This PR raises the version of Ruby for Docker to 2.4.3. The spec and integration tests work without change.