### PR TITLE
Update .travis.yml : support for 2.2 and 2.1 has ended 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ os:
   - linux
   - osx
 rvm:
-  - 2.1.0
-  - 2.2.0
   - 2.3.0
   - 2.4.0
 matrix:


### PR DESCRIPTION
support for 2.2 and 2.1 has ended 

https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/ and 

https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/