### PR TITLE
Support ruby-2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ was built with modularity, extensibility and simplicity in mind.
 
 ## Project Status: Maintenance-Only ##
 
-This project is not under active development, although we will continue to provide support for current users, and at least one more maintenance release: version 5.0. The version 5.0 release will include support for Ruby 2.4, and various other fixes. Future releases of Backup will only include bug fixes.
+This project is not under active development, although we will continue to provide support for current users, and at least one more maintenance release: version 5.0. The version 5.0 release will include support for Ruby 2.4, Ruby 2.5, and various other fixes. Future releases of Backup will only include bug fixes.
 
 If you use this project and would like to develop it further, please introduce yourself on the [maintainers wanted][Maintainers wanted] ticket.
 
-**Copyright (c) 2009-2017 [Michael van Rooijen][] ( [@mrrooijen] )**  
+**Copyright (c) 2009-2018 [Michael van Rooijen][] ( [@mrrooijen] )**  
 Released under the **MIT** [LICENSE](LICENSE).
 
 [Installation]:  http://backup.github.io/backup/v4/installation

--- a/spec/support/thread_conf.rb
+++ b/spec/support/thread_conf.rb
@@ -1,0 +1,10 @@
+RSpec.configure do |config|
+  config.before do
+    # Logs a $stderr message on Thread exceptions. Introduced with Ruby 2.4.
+    #
+    # Default rubies settings
+    # - ruby-2.4.x => Thread.report_on_exception = false
+    # - ruby-2.5.x => Thread.report_on_exception = true
+    Thread.report_on_exception = true if Thread.respond_to?(:report_on_exception)
+  end
+end


### PR DESCRIPTION
This PR is a replacement for https://github.com/backup/backup/pull/922.

I investigated about the strange warns reported into the previous PR and with `ruby-2.5` the `Thread.report_on_exception` default value changed from `false` to `true` so this is the main reason about these strange warns.

Digging into it I discovered that the warns were generated by a stubbed exception into a [spec](https://github.com/dalpo/backup/blob/615ddaba98ed80978a56cb588cdacc5593265741/spec/support/shared_examples/syncer/cloud.rb#L360) which was trying to simulate a network error.
Note: Now I've muted the warns only for this single spec.

So there isn't any issue with ruby-2.5 and it seems working correctly. 