### PR TITLE
Dropping mocha in favour of rspec-mocks

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -49,6 +49,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "0.48.1"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "3.5.0"
-  gem.add_development_dependency "mocha", "0.14.0"
   gem.add_development_dependency "timecop", "0.7.1"
 end

--- a/backup.gemspec
+++ b/backup.gemspec
@@ -48,6 +48,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rubocop", "0.48.1"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec", "3.5.0"
-  gem.add_development_dependency "timecop", "0.7.1"
+  gem.add_development_dependency "rspec", "3.8.0"
+  gem.add_development_dependency "timecop", "0.9.1"
 end

--- a/spec/cleaner_spec.rb
+++ b/spec/cleaner_spec.rb
@@ -16,16 +16,15 @@ module Backup
 
       context "when no temporary packaging folder or package files exist" do
         it "does nothing" do
-          File \
-            .expects(:exist?)
+          expect(File).to receive(:exist?)
             .with(File.join(Config.tmp_path, "test_trigger"))
-            .returns(false)
+            .and_return(false)
 
-          Cleaner.expects(:package_files_for).with("test_trigger").returns([])
+          expect(Cleaner).to receive(:package_files_for).with("test_trigger").and_return([])
 
-          FileUtils.expects(:rm_rf).never
-          FileUtils.expects(:rm_f).never
-          Logger.expects(:warn).never
+          expect(FileUtils).to receive(:rm_rf).never
+          expect(FileUtils).to receive(:rm_f).never
+          expect(Logger).to receive(:warn).never
 
           Cleaner.prepare(model)
         end
@@ -33,20 +32,18 @@ module Backup
 
       context "when a temporary packaging folder exists" do
         it "removes the folder and logs a warning" do
-          File \
-            .expects(:exist?)
+          expect(File).to receive(:exist?)
             .with(File.join(Config.tmp_path, "test_trigger"))
-            .returns(true)
+            .and_return(true)
 
-          Cleaner.expects(:package_files_for).with("test_trigger").returns([])
+          expect(Cleaner).to receive(:package_files_for).with("test_trigger").and_return([])
 
-          FileUtils \
-            .expects(:rm_rf)
+          expect(FileUtils).to receive(:rm_rf)
             .with(File.join(Config.tmp_path, "test_trigger"))
 
-          FileUtils.expects(:rm_f).never
+          expect(FileUtils).to receive(:rm_f).never
 
-          Logger.expects(:warn).with do |err|
+          expect(Logger).to receive(:warn) do |err|
             expect(err).to be_an_instance_of Cleaner::Error
             expect(err.message).to eq(<<-EOS.gsub(/^ +/, "  ").strip)
               Cleaner::Error: Cleanup Warning
@@ -63,21 +60,19 @@ module Backup
 
       context "when package files exist" do
         it "removes the files and logs a warning" do
-          File \
-            .expects(:exist?)
+          expect(File).to receive(:exist?)
             .with(File.join(Config.tmp_path, "test_trigger"))
-            .returns(false)
+            .and_return(false)
 
-          Cleaner \
-            .expects(:package_files_for)
+          expect(Cleaner).to receive(:package_files_for)
             .with("test_trigger")
-            .returns(["file1", "file2"])
+            .and_return(["file1", "file2"])
 
-          FileUtils.expects(:rm_rf).never
-          FileUtils.expects(:rm_f).with("file1")
-          FileUtils.expects(:rm_f).with("file2")
+          expect(FileUtils).to receive(:rm_rf).never
+          expect(FileUtils).to receive(:rm_f).with("file1")
+          expect(FileUtils).to receive(:rm_f).with("file2")
 
-          Logger.expects(:warn).with do |err|
+          expect(Logger).to receive(:warn) do |err|
             expect(err).to be_an_instance_of Cleaner::Error
             expect(err.message).to eq(<<-EOS.gsub(/^ +/, "  ").strip)
               Cleaner::Error: Cleanup Warning
@@ -96,24 +91,21 @@ module Backup
 
       context "when both the temporary packaging folder and package files exist" do
         it "removes both and logs a warning" do
-          File \
-            .expects(:exist?)
+          expect(File).to receive(:exist?)
             .with(File.join(Config.tmp_path, "test_trigger"))
-            .returns(true)
+            .and_return(true)
 
-          Cleaner \
-            .expects(:package_files_for)
+          expect(Cleaner).to receive(:package_files_for)
             .with("test_trigger")
-            .returns(["file1", "file2"])
+            .and_return(["file1", "file2"])
 
-          FileUtils \
-            .expects(:rm_rf)
+          expect(FileUtils).to receive(:rm_rf)
             .with(File.join(Config.tmp_path, "test_trigger"))
 
-          FileUtils.expects(:rm_f).with("file1")
-          FileUtils.expects(:rm_f).with("file2")
+          expect(FileUtils).to receive(:rm_f).with("file1")
+          expect(FileUtils).to receive(:rm_f).with("file2")
 
-          Logger.expects(:warn).with do |err|
+          expect(Logger).to receive(:warn) do |err|
             expect(err).to be_an_instance_of Cleaner::Error
             expect(err.message).to eq(<<-EOS.gsub(/^ +/, "  ").strip)
               Cleaner::Error: Cleanup Warning
@@ -137,9 +129,8 @@ module Backup
 
     describe "#remove_packaging" do
       it "removes the packaging directory" do
-        Logger.expects(:info).with("Cleaning up the temporary files...")
-        FileUtils \
-          .expects(:rm_rf)
+        expect(Logger).to receive(:info).with("Cleaning up the temporary files...")
+        expect(FileUtils).to receive(:rm_rf)
           .with(File.join(Config.tmp_path, "test_trigger"))
         Cleaner.remove_packaging(model)
       end
@@ -147,10 +138,10 @@ module Backup
 
     describe "#remove_package" do
       it "removes the package files" do
-        package = stub(filenames: ["file1", "file2"])
-        Backup::Logger.expects(:info).with("Cleaning up the package files...")
-        FileUtils.expects(:rm_f).with(File.join(Config.tmp_path, "file1"))
-        FileUtils.expects(:rm_f).with(File.join(Config.tmp_path, "file2"))
+        package = double(Backup::Package, filenames: ["file1", "file2"])
+        expect(Backup::Logger).to receive(:info).with("Cleaning up the package files...")
+        expect(FileUtils).to receive(:rm_f).with(File.join(Config.tmp_path, "file1"))
+        expect(FileUtils).to receive(:rm_f).with(File.join(Config.tmp_path, "file2"))
         Cleaner.remove_package(package)
       end
     end
@@ -167,14 +158,13 @@ module Backup
 
       context "when no temporary packaging folder or package files exist" do
         it "does nothing" do
-          File \
-            .expects(:exist?)
+          expect(File).to receive(:exist?)
             .with(File.join(Config.tmp_path, "test_trigger"))
-            .returns(false)
+            .and_return(false)
 
-          Cleaner.expects(:package_files_for).with("test_trigger").returns([])
+          expect(Cleaner).to receive(:package_files_for).with("test_trigger").and_return([])
 
-          Logger.expects(:warn).never
+          expect(Logger).to receive(:warn).never
 
           Cleaner.warnings(model)
         end
@@ -182,14 +172,13 @@ module Backup
 
       context "when a temporary packaging folder exists" do
         it "logs a warning" do
-          File \
-            .expects(:exist?)
+          expect(File).to receive(:exist?)
             .with(File.join(Config.tmp_path, "test_trigger"))
-            .returns(true)
+            .and_return(true)
 
-          Cleaner.expects(:package_files_for).with("test_trigger").returns([])
+          expect(Cleaner).to receive(:package_files_for).with("test_trigger").and_return([])
 
-          Logger.expects(:warn).with do |err|
+          expect(Logger).to receive(:warn) do |err|
             expect(err).to be_an_instance_of Cleaner::Error
             expect(err.message).to eq(<<-EOS.gsub(/^ +/, "  ").strip)
               Cleaner::Error: Cleanup Warning
@@ -206,16 +195,15 @@ module Backup
 
       context "when package files exist" do
         it "logs a warning" do
-          File \
-            .expects(:exist?).with(File.join(Config.tmp_path, "test_trigger"))
-            .returns(false)
+          expect(File).to receive(:exist?)
+            .with(File.join(Config.tmp_path, "test_trigger"))
+            .and_return(false)
 
-          Cleaner \
-            .expects(:package_files_for)
+          expect(Cleaner).to receive(:package_files_for)
             .with("test_trigger")
-            .returns(["file1", "file2"])
+            .and_return(["file1", "file2"])
 
-          Logger.expects(:warn).with do |err|
+          expect(Logger).to receive(:warn) do |err|
             expect(err).to be_an_instance_of Cleaner::Error
             expect(err.message).to eq(<<-EOS.gsub(/^ +/, "  ").strip)
               Cleaner::Error: Cleanup Warning
@@ -233,17 +221,15 @@ module Backup
 
       context "when both the temporary packaging folder and package files exist" do
         it "logs a warning" do
-          File \
-            .expects(:exist?)
+          expect(File).to receive(:exist?)
             .with(File.join(Config.tmp_path, "test_trigger"))
-            .returns(true)
+            .and_return(true)
 
-          Cleaner \
-            .expects(:package_files_for)
+          expect(Cleaner).to receive(:package_files_for)
             .with("test_trigger")
-            .returns(["file1", "file2"])
+            .and_return(["file1", "file2"])
 
-          Logger.expects(:warn).with do |err|
+          expect(Logger).to receive(:warn) do |err|
             expect(err).to be_an_instance_of Cleaner::Error
             expect(err.message).to eq(<<-EOS.gsub(/^ +/, "  ").strip)
               Cleaner::Error: Cleanup Warning

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -19,12 +19,12 @@ describe "Backup::CLI" do
       let(:logger_options) { Backup::Logger.instance_variable_get(:@config).dsl }
 
       before do
-        Backup::Config.expects(:load).in_sequence(s)
-        Backup::Logger.expects(:start!).in_sequence(s)
-        model_a.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
-        model_b.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
+        expect(Backup::Config).to receive(:load).ordered
+        expect(Backup::Logger).to receive(:start!).ordered
+        expect(model_a).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
+        expect(model_b).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
       end
 
       it "configures console and logfile loggers by default" do
@@ -93,15 +93,15 @@ describe "Backup::CLI" do
       let(:model_c) { Backup::Model.new(:test_trigger_c, "test label c") }
 
       before do
-        Backup::Logger.expects(:configure).in_sequence(s)
-        Backup::Config.expects(:load).in_sequence(s)
-        Backup::Logger.expects(:start!).in_sequence(s)
+        expect(Backup::Logger).to receive(:configure).ordered
+        expect(Backup::Config).to receive(:load).ordered
+        expect(Backup::Logger).to receive(:start!).ordered
       end
 
       it "performs a given trigger" do
-        model_a.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
-        model_b.expects(:perform!).never
+        expect(model_a).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
+        expect(model_b).to receive(:perform!).never
 
         ARGV.replace(
           ["perform", "-t", "test_trigger_a"]
@@ -110,10 +110,10 @@ describe "Backup::CLI" do
       end
 
       it "performs multiple triggers" do
-        model_a.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
-        model_b.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
+        expect(model_a).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
+        expect(model_b).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
 
         ARGV.replace(
           ["perform", "-t", "test_trigger_a,test_trigger_b"]
@@ -122,12 +122,12 @@ describe "Backup::CLI" do
       end
 
       it "performs multiple models that share a trigger name" do
-        model_c.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
+        expect(model_c).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
 
         model_d = Backup::Model.new(:test_trigger_c, "test label d")
-        model_d.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
+        expect(model_d).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
 
         ARGV.replace(
           ["perform", "-t", "test_trigger_c"]
@@ -136,12 +136,12 @@ describe "Backup::CLI" do
       end
 
       it "performs unique models only once, in the order first found" do
-        model_a.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
-        model_b.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
-        model_c.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
+        expect(model_a).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
+        expect(model_b).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
+        expect(model_c).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
 
         ARGV.replace(
           ["perform", "-t", "test_trigger_a,test_trigger_b,test_trigger_c,test_trigger_b"]
@@ -150,12 +150,12 @@ describe "Backup::CLI" do
       end
 
       it "performs unique models only once, in the order first found (wildcard)" do
-        model_a.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
-        model_b.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
-        model_c.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
+        expect(model_a).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
+        expect(model_b).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
+        expect(model_c).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
 
         ARGV.replace(
           ["perform", "-t", "test_trigger_*"]
@@ -166,16 +166,16 @@ describe "Backup::CLI" do
 
     describe "failure to prepare for backups" do
       before do
-        Backup::Logger.expects(:configure).in_sequence(s)
-        Backup::Logger.expects(:start!).never
-        model_a.expects(:perform!).never
-        model_b.expects(:perform!).never
-        Backup::Logger.expects(:clear!).never
+        expect(Backup::Logger).to receive(:configure).ordered
+        expect(Backup::Logger).to receive(:start!).never
+        expect(model_a).to receive(:perform!).never
+        expect(model_b).to receive(:perform!).never
+        expect(Backup::Logger).to receive(:clear!).never
       end
 
       describe "when errors are raised while loading config.rb" do
         before do
-          Backup::Config.expects(:load).in_sequence(s).raises("config load error")
+          expect(Backup::Config).to receive(:load).ordered.and_raise("config load error")
         end
 
         it "aborts with status code 3 and logs messages to the console only" do
@@ -186,12 +186,12 @@ describe "Backup::CLI" do
             end,
             proc { |err| expect(err).to be_a(String) }
           ]
-          Backup::Logger.expects(:error).in_sequence(s).times(2).with do |err|
+          expect(Backup::Logger).to receive(:error).ordered.exactly(2).times do |err|
             expectation = expectations.shift
             expectation.call(err) if expectation
           end
 
-          Backup::Logger.expects(:abort!).in_sequence(s)
+          expect(Backup::Logger).to receive(:abort!).ordered
 
           expect do
             ARGV.replace(
@@ -204,18 +204,18 @@ describe "Backup::CLI" do
 
       describe "when no models are found for the given triggers" do
         before do
-          Backup::Config.expects(:load).in_sequence(s)
+          expect(Backup::Config).to receive(:load).ordered
         end
 
         it "aborts and logs messages to the console only" do
-          Backup::Logger.expects(:error).in_sequence(s).with do |err|
+          expect(Backup::Logger).to receive(:error).ordered do |err|
             expect(err).to be_a(Backup::CLI::Error)
             expect(err.message).to match(
               /No Models found for trigger\(s\) 'test_trigger_foo'/
             )
           end
 
-          Backup::Logger.expects(:abort!).in_sequence(s)
+          expect(Backup::Logger).to receive(:abort!).ordered
 
           expect do
             ARGV.replace(
@@ -228,31 +228,31 @@ describe "Backup::CLI" do
     end # describe 'failure to prepare for backups'
 
     describe "exit codes and notifications" do
-      let(:notifier_a) { mock }
-      let(:notifier_b) { mock }
-      let(:notifier_c) { mock }
-      let(:notifier_d) { mock }
+      let(:notifier_a) { double }
+      let(:notifier_b) { double }
+      let(:notifier_c) { double }
+      let(:notifier_d) { double }
 
       before do
-        Backup::Config.stubs(:load)
-        Backup::Logger.stubs(:start!)
-        model_a.stubs(:notifiers).returns([notifier_a, notifier_c])
-        model_b.stubs(:notifiers).returns([notifier_b, notifier_d])
+        allow(Backup::Config).to receive(:load)
+        allow(Backup::Logger).to receive(:start!)
+        allow(model_a).to receive(:notifiers).and_return([notifier_a, notifier_c])
+        allow(model_b).to receive(:notifiers).and_return([notifier_b, notifier_d])
       end
 
       specify "when jobs are all successful" do
-        model_a.stubs(:exit_status).returns(0)
-        model_b.stubs(:exit_status).returns(0)
+        allow(model_a).to receive(:exit_status).and_return(0)
+        allow(model_b).to receive(:exit_status).and_return(0)
 
-        model_a.expects(:perform!).in_sequence(s)
-        notifier_a.expects(:perform!).in_sequence(s)
-        notifier_c.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
+        expect(model_a).to receive(:perform!).ordered
+        expect(notifier_a).to receive(:perform!).ordered
+        expect(notifier_c).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
 
-        model_b.expects(:perform!).in_sequence(s)
-        notifier_b.expects(:perform!).in_sequence(s)
-        notifier_d.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
+        expect(model_b).to receive(:perform!).ordered
+        expect(notifier_b).to receive(:perform!).ordered
+        expect(notifier_d).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
 
         ARGV.replace(
           ["perform", "-t", "test_trigger_a,test_trigger_b"]
@@ -261,18 +261,18 @@ describe "Backup::CLI" do
       end
 
       specify "when a job has warnings" do
-        model_a.stubs(:exit_status).returns(1)
-        model_b.stubs(:exit_status).returns(0)
+        allow(model_a).to receive(:exit_status).and_return(1)
+        allow(model_b).to receive(:exit_status).and_return(0)
 
-        model_a.expects(:perform!).in_sequence(s)
-        notifier_a.expects(:perform!).in_sequence(s)
-        notifier_c.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
+        expect(model_a).to receive(:perform!).ordered
+        expect(notifier_a).to receive(:perform!).ordered
+        expect(notifier_c).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
 
-        model_b.expects(:perform!).in_sequence(s)
-        notifier_b.expects(:perform!).in_sequence(s)
-        notifier_d.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
+        expect(model_b).to receive(:perform!).ordered
+        expect(notifier_b).to receive(:perform!).ordered
+        expect(notifier_d).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
 
         expect do
           ARGV.replace(
@@ -283,18 +283,18 @@ describe "Backup::CLI" do
       end
 
       specify "when a job has non-fatal errors" do
-        model_a.stubs(:exit_status).returns(2)
-        model_b.stubs(:exit_status).returns(0)
+        allow(model_a).to receive(:exit_status).and_return(2)
+        allow(model_b).to receive(:exit_status).and_return(0)
 
-        model_a.expects(:perform!).in_sequence(s)
-        notifier_a.expects(:perform!).in_sequence(s)
-        notifier_c.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
+        expect(model_a).to receive(:perform!).ordered
+        expect(notifier_a).to receive(:perform!).ordered
+        expect(notifier_c).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
 
-        model_b.expects(:perform!).in_sequence(s)
-        notifier_b.expects(:perform!).in_sequence(s)
-        notifier_d.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
+        expect(model_b).to receive(:perform!).ordered
+        expect(notifier_b).to receive(:perform!).ordered
+        expect(notifier_d).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
 
         expect do
           ARGV.replace(
@@ -305,15 +305,15 @@ describe "Backup::CLI" do
       end
 
       specify "when a job has fatal errors" do
-        model_a.stubs(:exit_status).returns(3)
-        model_b.stubs(:exit_status).returns(0)
+        allow(model_a).to receive(:exit_status).and_return(3)
+        allow(model_b).to receive(:exit_status).and_return(0)
 
-        model_a.expects(:perform!).in_sequence(s)
-        notifier_a.expects(:perform!).in_sequence(s)
-        notifier_c.expects(:perform!).in_sequence(s)
+        expect(model_a).to receive(:perform!).ordered
+        expect(notifier_a).to receive(:perform!).ordered
+        expect(notifier_c).to receive(:perform!).ordered
 
-        Backup::Logger.expects(:clear!).never
-        model_b.expects(:perform!).never
+        expect(Backup::Logger).to receive(:clear!).never
+        expect(model_b).to receive(:perform!).never
 
         expect do
           ARGV.replace(
@@ -324,18 +324,18 @@ describe "Backup::CLI" do
       end
 
       specify "when jobs have errors and warnings" do
-        model_a.stubs(:exit_status).returns(2)
-        model_b.stubs(:exit_status).returns(1)
+        allow(model_a).to receive(:exit_status).and_return(2)
+        allow(model_b).to receive(:exit_status).and_return(1)
 
-        model_a.expects(:perform!).in_sequence(s)
-        notifier_a.expects(:perform!).in_sequence(s)
-        notifier_c.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
+        expect(model_a).to receive(:perform!).ordered
+        expect(notifier_a).to receive(:perform!).ordered
+        expect(notifier_c).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
 
-        model_b.expects(:perform!).in_sequence(s)
-        notifier_b.expects(:perform!).in_sequence(s)
-        notifier_d.expects(:perform!).in_sequence(s)
-        Backup::Logger.expects(:clear!).in_sequence(s)
+        expect(model_b).to receive(:perform!).ordered
+        expect(notifier_b).to receive(:perform!).ordered
+        expect(notifier_d).to receive(:perform!).ordered
+        expect(Backup::Logger).to receive(:clear!).ordered
 
         expect do
           ARGV.replace(
@@ -348,7 +348,12 @@ describe "Backup::CLI" do
 
     describe "--check" do
       it "runs the check command" do
-        cli.any_instance.expects(:check).raises(SystemExit)
+        # RSpec aliases old check method to __check_without_any_instance__,
+        # and thor does not like it, rendering a warning message about the lack
+        # of description. Here we define a description before stubbing the method.
+        cli.desc "check", "RSpec Check Command"
+
+        expect_any_instance_of(cli).to receive(:check).and_raise(SystemExit)
         expect do
           ARGV.replace(
             ["perform", "-t", "test_trigger_foo", "--check"]
@@ -361,7 +366,7 @@ describe "Backup::CLI" do
 
   describe "#check" do
     it "fails if errors are raised" do
-      Backup::Config.stubs(:load).raises("an error")
+      allow(Backup::Config).to receive(:load).and_raise("an error")
 
       out, err = capture_io do
         ARGV.replace(["check"])
@@ -376,7 +381,7 @@ describe "Backup::CLI" do
     end
 
     it "fails if warnings are issued" do
-      Backup::Config.stubs(:load).with do
+      allow(Backup::Config).to receive(:load) do
         Backup::Logger.warn "warning message"
       end
 
@@ -393,7 +398,7 @@ describe "Backup::CLI" do
     end
 
     it "succeeds if there are no errors or warnings" do
-      Backup::Config.stubs(:load)
+      allow(Backup::Config).to receive(:load)
 
       out, err = capture_io do
         ARGV.replace(["check"])
@@ -408,10 +413,10 @@ describe "Backup::CLI" do
 
     it "uses --config-file if given" do
       # Note: Thor#options is returning a HashWithIndifferentAccess.
-      Backup::Config.expects(:load).with do |options|
+      expect(Backup::Config).to receive(:load) do |options|
         options[:config_file] == "/my/config.rb"
       end
-      Backup::Logger.stubs(:abort!) # suppress output
+      allow(Backup::Logger).to receive(:abort!) # suppress output
 
       ARGV.replace(["check", "--config-file", "/my/config.rb"])
       expect do
@@ -464,8 +469,8 @@ describe "Backup::CLI" do
             FileUtils.mkdir_p(File.join(path, "custom"))
             FileUtils.touch(config_file)
 
-            cli::Helpers.expects(:overwrite?).with(config_file).never
-            cli::Helpers.expects(:overwrite?).with(model_file).returns(true)
+            expect(cli::Helpers).to receive(:overwrite?).with(config_file).never
+            expect(cli::Helpers).to receive(:overwrite?).with(model_file).and_return(true)
 
             out, err = capture_io do
               ARGV.replace([
@@ -492,7 +497,7 @@ describe "Backup::CLI" do
             FileUtils.mkdir_p(File.dirname(model_file))
             FileUtils.touch(model_file)
 
-            $stdin.expects(:gets).returns("n")
+            expect($stdin).to receive(:gets).and_return("n")
 
             out, err = capture_io do
               ARGV.replace([
@@ -609,7 +614,7 @@ describe "Backup::CLI" do
           FileUtils.mkdir_p(File.dirname(config_file))
           FileUtils.touch(config_file)
 
-          $stdin.expects(:gets).returns("n")
+          expect($stdin).to receive(:gets).and_return("n")
 
           out, err = capture_io do
             ARGV.replace(["generate:config"])
@@ -648,28 +653,28 @@ describe "Backup::CLI" do
 
     describe "#overwrite?" do
       it "prompts user and accepts confirmation" do
-        File.expects(:exist?).with("a/path").returns(true)
-        $stderr.expects(:print).with(
+        expect(File).to receive(:exist?).with("a/path").and_return(true)
+        expect($stderr).to receive(:print).with(
           "A file already exists at 'a/path'.\nDo you want to overwrite? [y/n] "
         )
-        $stdin.expects(:gets).returns("yes\n")
+        expect($stdin).to receive(:gets).and_return("yes\n")
 
         expect(helpers.overwrite?("a/path")).to be_truthy
       end
 
       it "prompts user and accepts cancelation" do
-        File.expects(:exist?).with("a/path").returns(true)
-        $stderr.expects(:print).with(
+        expect(File).to receive(:exist?).with("a/path").and_return(true)
+        expect($stderr).to receive(:print).with(
           "A file already exists at 'a/path'.\nDo you want to overwrite? [y/n] "
         )
-        $stdin.expects(:gets).returns("no\n")
+        expect($stdin).to receive(:gets).and_return("no\n")
 
         expect(helpers.overwrite?("a/path")).to be_falsy
       end
 
       it "returns true if path does not exist" do
-        File.expects(:exist?).with("a/path").returns(false)
-        $stderr.expects(:print).never
+        expect(File).to receive(:exist?).with("a/path").and_return(false)
+        expect($stderr).to receive(:print).never
         expect(helpers.overwrite?("a/path")).to eq(true)
       end
     end

--- a/spec/cloud_io/cloud_files_spec.rb
+++ b/spec/cloud_io/cloud_files_spec.rb
@@ -288,7 +288,7 @@ module Backup # rubocop:disable Metrics/ModuleLength
           .with("my_container", ["obj_a_name", "obj_b_name"]).and_return(resp_ok)
 
         objects = [object_a, object_b]
-        expect { cloud_io.delete(objects) }.not_to change { objects }
+        expect { cloud_io.delete(objects) }.not_to change { objects.map(&:inspect) }
       end
 
       it "accepts a single name" do

--- a/spec/cloud_io/cloud_files_spec.rb
+++ b/spec/cloud_io/cloud_files_spec.rb
@@ -1,13 +1,13 @@
 require "spec_helper"
 require "backup/cloud_io/cloud_files"
 
-module Backup
+module Backup # rubocop:disable Metrics/ModuleLength
   describe CloudIO::CloudFiles do
-    let(:connection) { mock }
+    let(:connection) { double }
 
     describe "#upload" do
       before do
-        described_class.any_instance.expects(:create_containers)
+        expect_any_instance_of(described_class).to receive(:create_containers)
       end
 
       context "with SLO support" do
@@ -18,19 +18,19 @@ module Backup
             segment_size: 5
           )
         end
-        let(:segments) { mock }
+        let(:segments) { double }
 
         context "when src file is larger than segment_size" do
           before do
-            File.expects(:size).with("/src/file").returns(10 * 1024**2)
+            expect(File).to receive(:size).with("/src/file").and_return(10 * 1024**2)
           end
 
           it "uploads as a SLO" do
-            cloud_io.expects(:upload_segments).with(
+            expect(cloud_io).to receive(:upload_segments).with(
               "/src/file", "dest/file", 5 * 1024**2, 10 * 1024**2
-            ).returns(segments)
-            cloud_io.expects(:upload_manifest).with("dest/file", segments)
-            cloud_io.expects(:put_object).never
+            ).and_return(segments)
+            expect(cloud_io).to receive(:upload_manifest).with("dest/file", segments)
+            expect(cloud_io).to receive(:put_object).never
 
             cloud_io.upload("/src/file", "dest/file")
           end
@@ -38,13 +38,13 @@ module Backup
 
         context "when src file is not larger than segment_size" do
           before do
-            File.expects(:size).with("/src/file").returns(5 * 1024**2)
+            expect(File).to receive(:size).with("/src/file").and_return(5 * 1024**2)
           end
 
           it "uploads as a non-SLO" do
-            cloud_io.expects(:put_object).with("/src/file", "dest/file")
-            cloud_io.expects(:upload_segments).never
-            cloud_io.expects(:upload_manifest).never
+            expect(cloud_io).to receive(:put_object).with("/src/file", "dest/file")
+            expect(cloud_io).to receive(:upload_segments).never
+            expect(cloud_io).to receive(:upload_manifest).never
 
             cloud_io.upload("/src/file", "dest/file")
           end
@@ -52,17 +52,17 @@ module Backup
 
         context "when segment_size is too small for the src file" do
           before do
-            File.expects(:size).with("/src/file").returns((5000 * 1024**2) + 1)
+            expect(File).to receive(:size).with("/src/file").and_return((5000 * 1024**2) + 1)
           end
 
           it "warns and adjusts the segment_size" do
-            cloud_io.expects(:upload_segments).with(
+            expect(cloud_io).to receive(:upload_segments).with(
               "/src/file", "dest/file", 6 * 1024**2, (5000 * 1024**2) + 1
-            ).returns(segments)
-            cloud_io.expects(:upload_manifest).with("dest/file", segments)
-            cloud_io.expects(:put_object).never
+            ).and_return(segments)
+            expect(cloud_io).to receive(:upload_manifest).with("dest/file", segments)
+            expect(cloud_io).to receive(:put_object).never
 
-            Logger.expects(:warn).with do |err|
+            expect(Logger).to receive(:warn) do |err|
               expect(err.message).to include(
                 "#segment_size of 5 MiB has been adjusted\n  to 6 MiB"
               )
@@ -74,14 +74,14 @@ module Backup
 
         context "when src file is too large" do
           before do
-            File.expects(:size).with("/src/file")
-              .returns(described_class::MAX_SLO_SIZE + 1)
+            expect(File).to receive(:size).with("/src/file")
+              .and_return(described_class::MAX_SLO_SIZE + 1)
           end
 
           it "raises an error" do
-            cloud_io.expects(:upload_segments).never
-            cloud_io.expects(:upload_manifest).never
-            cloud_io.expects(:put_object).never
+            expect(cloud_io).to receive(:upload_segments).never
+            expect(cloud_io).to receive(:upload_manifest).never
+            expect(cloud_io).to receive(:put_object).never
 
             expect do
               cloud_io.upload("/src/file", "dest/file")
@@ -99,17 +99,17 @@ module Backup
         end
 
         before do
-          cloud_io.expects(:upload_segments).never
+          expect(cloud_io).to receive(:upload_segments).never
         end
 
         context "when src file size is ok" do
           before do
-            File.expects(:size).with("/src/file")
-              .returns(described_class::MAX_FILE_SIZE)
+            expect(File).to receive(:size).with("/src/file")
+              .and_return(described_class::MAX_FILE_SIZE)
           end
 
           it "uploads as non-SLO" do
-            cloud_io.expects(:put_object).with("/src/file", "dest/file")
+            expect(cloud_io).to receive(:put_object).with("/src/file", "dest/file")
 
             cloud_io.upload("/src/file", "dest/file")
           end
@@ -117,12 +117,12 @@ module Backup
 
         context "when src file is too large" do
           before do
-            File.expects(:size).with("/src/file")
-              .returns(described_class::MAX_FILE_SIZE + 1)
+            expect(File).to receive(:size).with("/src/file")
+              .and_return(described_class::MAX_FILE_SIZE + 1)
           end
 
           it "raises an error" do
-            cloud_io.expects(:put_object).never
+            expect(cloud_io).to receive(:put_object).never
 
             expect do
               cloud_io.upload("/src/file", "dest/file")
@@ -142,21 +142,21 @@ module Backup
       end
 
       before do
-        cloud_io.stubs(:connection).returns(connection)
-        cloud_io.expects(:create_containers)
+        allow(cloud_io).to receive(:connection).and_return(connection)
+        expect(cloud_io).to receive(:create_containers)
       end
 
       it "ensures prefix ends with /" do
-        connection.expects(:get_container)
+        expect(connection).to receive(:get_container)
           .with("my_container", prefix: "foo/bar/")
-          .returns(stub(body: []))
+          .and_return(double("response", body: []))
         expect(cloud_io.objects("foo/bar")).to eq []
       end
 
       it "returns an empty array when no objects are found" do
-        connection.expects(:get_container)
+        expect(connection).to receive(:get_container)
           .with("my_container", prefix: "foo/bar/")
-          .returns(stub(body: []))
+          .and_return(double("response", body: []))
         expect(cloud_io.objects("foo/bar/")).to eq []
       end
 
@@ -166,11 +166,11 @@ module Backup
         end
 
         it "returns all objects" do
-          cloud_io.expects(:with_retries)
-            .with("GET 'my_container/foo/bar/*'").yields
-          connection.expects(:get_container)
+          expect(cloud_io).to receive(:with_retries)
+            .with("GET 'my_container/foo/bar/*'").and_yield
+          expect(connection).to receive(:get_container)
             .with("my_container", prefix: "foo/bar/")
-            .returns(stub(body: resp_body))
+            .and_return(double("response", body: resp_body))
 
           objects = cloud_io.objects("foo/bar/")
           expect(objects.count).to be 10
@@ -193,28 +193,32 @@ module Backup
         end
 
         it "returns all objects" do
-          cloud_io.expects(:with_retries).twice
-            .with("GET 'my_container/foo/bar/*'").yields
-          connection.expects(:get_container)
+          expect(cloud_io).to receive(:with_retries).twice
+            .with("GET 'my_container/foo/bar/*'").and_yield
+          expect(connection).to receive(:get_container)
             .with("my_container", prefix: "foo/bar/")
-            .returns(stub(body: resp_body_a))
-          connection.expects(:get_container)
+            .and_return(double("response", body: resp_body_a))
+          expect(connection).to receive(:get_container)
             .with("my_container", prefix: "foo/bar/", marker: "name_9999")
-            .returns(stub(body: resp_body_b))
+            .and_return(double("response", body: resp_body_b))
 
           objects = cloud_io.objects("foo/bar/")
           expect(objects.count).to be 10_010
         end
 
         it "retries on errors" do
-          connection.expects(:get_container).twice
+          expect(connection).to receive(:get_container).once
             .with("my_container", prefix: "foo/bar/")
-            .raises("error").then
-            .returns(stub(body: resp_body_a))
-          connection.expects(:get_container).twice
+            .and_raise("error")
+          expect(connection).to receive(:get_container).once
+            .with("my_container", prefix: "foo/bar/")
+            .and_return(double("response", body: resp_body_a))
+          expect(connection).to receive(:get_container).once
             .with("my_container", prefix: "foo/bar/", marker: "name_9999")
-            .raises("error").then
-            .returns(stub(body: resp_body_b))
+            .and_raise("error")
+          expect(connection).to receive(:get_container).once
+            .with("my_container", prefix: "foo/bar/", marker: "name_9999")
+            .and_return(double("response", body: resp_body_b))
 
           objects = cloud_io.objects("foo/bar/")
           expect(objects.count).to be 10_010
@@ -232,14 +236,17 @@ module Backup
       end
 
       before do
-        cloud_io.stubs(:connection).returns(connection)
+        allow(cloud_io).to receive(:connection).and_return(connection)
       end
 
       it "returns head_object response with retries" do
-        object = stub(name: "obj_name")
-        connection.expects(:head_object).twice
+        object = double("response", name: "obj_name")
+        expect(connection).to receive(:head_object).once
           .with("my_container", "obj_name")
-          .raises("error").then.returns(:response)
+          .and_raise("error")
+        expect(connection).to receive(:head_object).once
+          .with("my_container", "obj_name")
+          .and_return(:response)
         expect(cloud_io.head_object(object)).to eq :response
       end
     end # describe '#head_object'
@@ -252,20 +259,20 @@ module Backup
           retry_waitsec: 0
         )
       end
-      let(:resp_ok) { stub(body: { "Response Status" => "200 OK" }) }
-      let(:resp_bad) { stub(body: { "Response Status" => "400 Bad Request" }) }
+      let(:resp_ok) { double("response", body: { "Response Status" => "200 OK" }) }
+      let(:resp_bad) { double("response", body: { "Response Status" => "400 Bad Request" }) }
 
       before do
-        cloud_io.stubs(:connection).returns(connection)
+        allow(cloud_io).to receive(:connection).and_return(connection)
       end
 
       it "accepts a single Object" do
         object = described_class::Object.new(
           :foo, "name" => "obj_name", "hash" => "obj_hash"
         )
-        cloud_io.expects(:with_retries).with("DELETE Multiple Objects").yields
-        connection.expects(:delete_multiple_objects)
-          .with("my_container", ["obj_name"]).returns(resp_ok)
+        expect(cloud_io).to receive(:with_retries).with("DELETE Multiple Objects").and_yield
+        expect(connection).to receive(:delete_multiple_objects)
+          .with("my_container", ["obj_name"]).and_return(resp_ok)
         cloud_io.delete(object)
       end
 
@@ -276,32 +283,32 @@ module Backup
         object_b = described_class::Object.new(
           :foo, "name" => "obj_b_name", "hash" => "obj_b_hash"
         )
-        cloud_io.expects(:with_retries).with("DELETE Multiple Objects").yields
-        connection.expects(:delete_multiple_objects)
-          .with("my_container", ["obj_a_name", "obj_b_name"]).returns(resp_ok)
+        expect(cloud_io).to receive(:with_retries).with("DELETE Multiple Objects").and_yield
+        expect(connection).to receive(:delete_multiple_objects)
+          .with("my_container", ["obj_a_name", "obj_b_name"]).and_return(resp_ok)
 
         objects = [object_a, object_b]
         expect { cloud_io.delete(objects) }.not_to change { objects }
       end
 
       it "accepts a single name" do
-        cloud_io.expects(:with_retries).with("DELETE Multiple Objects").yields
-        connection.expects(:delete_multiple_objects)
-          .with("my_container", ["obj_name"]).returns(resp_ok)
+        expect(cloud_io).to receive(:with_retries).with("DELETE Multiple Objects").and_yield
+        expect(connection).to receive(:delete_multiple_objects)
+          .with("my_container", ["obj_name"]).and_return(resp_ok)
         cloud_io.delete("obj_name")
       end
 
       it "accepts multiple names" do
-        cloud_io.expects(:with_retries).with("DELETE Multiple Objects").yields
-        connection.expects(:delete_multiple_objects)
-          .with("my_container", ["obj_a_name", "obj_b_name"]).returns(resp_ok)
+        expect(cloud_io).to receive(:with_retries).with("DELETE Multiple Objects").and_yield
+        expect(connection).to receive(:delete_multiple_objects)
+          .with("my_container", ["obj_a_name", "obj_b_name"]).and_return(resp_ok)
 
         names = ["obj_a_name", "obj_b_name"]
         expect { cloud_io.delete(names) }.not_to change { names }
       end
 
       it "does nothing if empty array passed" do
-        connection.expects(:delete_multiple_objects).never
+        expect(connection).to receive(:delete_multiple_objects).never
         cloud_io.delete([])
       end
 
@@ -310,33 +317,39 @@ module Backup
         names_remaining = ["name"] * 10
         names_all = max_names + names_remaining
 
-        cloud_io.expects(:with_retries).twice.with("DELETE Multiple Objects").yields
-        connection.expects(:delete_multiple_objects)
-          .with("my_container", max_names).returns(resp_ok)
-        connection.expects(:delete_multiple_objects)
-          .with("my_container", names_remaining).returns(resp_ok)
+        expect(cloud_io).to receive(:with_retries).twice.with("DELETE Multiple Objects").and_yield
+        expect(connection).to receive(:delete_multiple_objects)
+          .with("my_container", max_names).and_return(resp_ok)
+        expect(connection).to receive(:delete_multiple_objects)
+          .with("my_container", names_remaining).and_return(resp_ok)
 
         expect { cloud_io.delete(names_all) }.not_to change { names_all }
       end
 
       it "retries on raised errors" do
-        connection.expects(:delete_multiple_objects).twice
+        expect(connection).to receive(:delete_multiple_objects).once
           .with("my_container", ["obj_name"])
-          .raises("error").then.returns(resp_ok)
+          .and_raise("error")
+        expect(connection).to receive(:delete_multiple_objects).once
+          .with("my_container", ["obj_name"])
+          .and_return(resp_ok)
         cloud_io.delete("obj_name")
       end
 
       it "retries on returned errors" do
-        connection.expects(:delete_multiple_objects).twice
+        expect(connection).to receive(:delete_multiple_objects).twice
           .with("my_container", ["obj_name"])
-          .returns(resp_bad).then.returns(resp_ok)
+          .and_return(resp_bad, resp_ok)
         cloud_io.delete("obj_name")
       end
 
       it "fails after retries exceeded" do
-        connection.expects(:delete_multiple_objects).twice
+        expect(connection).to receive(:delete_multiple_objects).once
           .with("my_container", ["obj_name"])
-          .raises("error message").then.returns(resp_bad)
+          .and_raise("error message")
+        expect(connection).to receive(:delete_multiple_objects).once
+          .with("my_container", ["obj_name"])
+          .and_return(resp_bad)
 
         expect do
           cloud_io.delete("obj_name")
@@ -378,44 +391,53 @@ module Backup
           :foo, "name" => "obj_b_name", "hash" => "obj_b_hash"
         )
       end
-      let(:resp_ok) { stub(body: { "Response Status" => "200 OK" }) }
-      let(:resp_bad) { stub(body: { "Response Status" => "400 Bad Request" }) }
+      let(:resp_ok) { double("response", body: { "Response Status" => "200 OK" }) }
+      let(:resp_bad) { double("response", body: { "Response Status" => "400 Bad Request" }) }
 
       before do
-        cloud_io.stubs(:connection).returns(connection)
+        allow(cloud_io).to receive(:connection).and_return(connection)
       end
 
       it "deletes a single SLO" do
-        connection.expects(:delete_static_large_object)
-          .with("my_container", "obj_a_name").returns(resp_ok)
+        expect(connection).to receive(:delete_static_large_object)
+          .with("my_container", "obj_a_name").and_return(resp_ok)
         cloud_io.delete_slo(object_a)
       end
 
       it "deletes a multiple SLOs" do
-        connection.expects(:delete_static_large_object)
-          .with("my_container", "obj_a_name").returns(resp_ok)
-        connection.expects(:delete_static_large_object)
-          .with("my_container", "obj_b_name").returns(resp_ok)
+        expect(connection).to receive(:delete_static_large_object)
+          .with("my_container", "obj_a_name").and_return(resp_ok)
+        expect(connection).to receive(:delete_static_large_object)
+          .with("my_container", "obj_b_name").and_return(resp_ok)
         cloud_io.delete_slo([object_a, object_b])
       end
 
       it "retries on raised and returned errors" do
-        connection.expects(:delete_static_large_object).twice
+        expect(connection).to receive(:delete_static_large_object).once
           .with("my_container", "obj_a_name")
-          .raises("error").then.returns(resp_ok)
-        connection.expects(:delete_static_large_object).twice
+          .and_raise("error")
+        expect(connection).to receive(:delete_static_large_object).once
+          .with("my_container", "obj_a_name")
+          .and_return(resp_ok)
+        expect(connection).to receive(:delete_static_large_object).twice
           .with("my_container", "obj_b_name")
-          .returns(resp_bad).then.returns(resp_ok)
+          .and_return(resp_bad, resp_ok)
         cloud_io.delete_slo([object_a, object_b])
       end
 
       it "fails after retries exceeded" do
-        connection.expects(:delete_static_large_object).twice
+        expect(connection).to receive(:delete_static_large_object).once
           .with("my_container", "obj_a_name")
-          .raises("error message").then.returns(resp_ok)
-        connection.expects(:delete_static_large_object).twice
+          .and_raise("error message")
+        expect(connection).to receive(:delete_static_large_object).once
+          .with("my_container", "obj_a_name")
+          .and_return(resp_ok)
+        expect(connection).to receive(:delete_static_large_object).once
           .with("my_container", "obj_b_name")
-          .returns(resp_bad).then.raises("failure")
+          .and_return(resp_bad)
+        expect(connection).to receive(:delete_static_large_object).once
+          .with("my_container", "obj_b_name")
+          .and_raise("failure")
 
         expect do
           cloud_io.delete_slo([object_a, object_b])
@@ -455,21 +477,21 @@ module Backup
       end
 
       it "caches a connection" do
-        Fog::Storage.expects(:new).once.with(
+        expect(Fog::Storage).to receive(:new).once.with(
           provider: "Rackspace",
           rackspace_username: "my_username",
           rackspace_api_key: "my_api_key",
           rackspace_auth_url: "my_auth_url",
           rackspace_region: "my_region",
           rackspace_servicenet: false
-        ).returns(connection)
+        ).and_return(connection)
 
         expect(cloud_io.send(:connection)).to be connection
         expect(cloud_io.send(:connection)).to be connection
       end
 
       it "passes along fog_options" do
-        Fog::Storage.expects(:new).with(provider: "Rackspace",
+        expect(Fog::Storage).to receive(:new).with(provider: "Rackspace",
                                           rackspace_username: "my_user",
                                           rackspace_api_key: "my_key",
                                           rackspace_auth_url: nil,
@@ -499,15 +521,18 @@ module Backup
           )
         end
         before do
-          cloud_io.stubs(:connection).returns(connection)
+          allow(cloud_io).to receive(:connection).and_return(connection)
         end
 
         it "creates containers once with retries" do
-          connection.expects(:put_container).twice
+          expect(connection).to receive(:put_container).twice
             .with("my_container")
-          connection.expects(:put_container).twice
+          expect(connection).to receive(:put_container).once
             .with("my_segments_container")
-            .raises("error").then.returns(nil)
+            .and_raise("error")
+          expect(connection).to receive(:put_container).once
+            .with("my_segments_container")
+            .and_return(nil)
 
           cloud_io.send(:create_containers)
           cloud_io.send(:create_containers)
@@ -523,13 +548,16 @@ module Backup
           )
         end
         before do
-          cloud_io.stubs(:connection).returns(connection)
+          allow(cloud_io).to receive(:connection).and_return(connection)
         end
 
         it "creates containers once with retries" do
-          connection.expects(:put_container).twice
+          expect(connection).to receive(:put_container).once
             .with("my_container")
-            .raises("error").then.returns(nil)
+            .and_raise("error")
+          expect(connection).to receive(:put_container).once
+            .with("my_container")
+            .and_return(nil)
 
           cloud_io.send(:create_containers)
           cloud_io.send(:create_containers)
@@ -545,27 +573,30 @@ module Backup
           retry_waitsec: 0
         )
       end
-      let(:file) { mock }
+      let(:file) { double }
 
       before do
-        cloud_io.stubs(:connection).returns(connection)
-        md5_file = mock
-        Digest::MD5.expects(:file).with("/src/file").returns(md5_file)
-        md5_file.expects(:hexdigest).returns("abc123")
+        allow(cloud_io).to receive(:connection).and_return(connection)
+        md5_file = double
+        expect(Digest::MD5).to receive(:file).with("/src/file").and_return(md5_file)
+        expect(md5_file).to receive(:hexdigest).and_return("abc123")
       end
 
       it "calls put_object with ETag" do
-        File.expects(:open).with("/src/file", "r").yields(file)
-        connection.expects(:put_object)
+        expect(File).to receive(:open).with("/src/file", "r").and_yield(file)
+        expect(connection).to receive(:put_object)
           .with("my_container", "dest/file", file, "ETag" => "abc123")
         cloud_io.send(:put_object, "/src/file", "dest/file")
       end
 
       it "fails after retries" do
-        File.expects(:open).twice.with("/src/file", "r").yields(file)
-        connection.expects(:put_object).twice
+        expect(File).to receive(:open).twice.with("/src/file", "r").and_yield(file)
+        expect(connection).to receive(:put_object).once
           .with("my_container", "dest/file", file, "ETag" => "abc123")
-          .raises("error1").then.raises("error2")
+          .and_raise("error1")
+        expect(connection).to receive(:put_object).once
+          .with("my_container", "dest/file", file, "ETag" => "abc123")
+          .and_raise("error2")
 
         expect do
           cloud_io.send(:put_object, "/src/file", "dest/file")
@@ -598,8 +629,8 @@ module Backup
         let(:delete_at) { cloud_io.send(:delete_at) }
 
         it "call put_object with X-Delete-At" do
-          File.expects(:open).with("/src/file", "r").yields(file)
-          connection.expects(:put_object).with(
+          expect(File).to receive(:open).with("/src/file", "r").and_yield(file)
+          expect(connection).to receive(:put_object).with(
             "my_container", "dest/file", file,
             "ETag" => "abc123", "X-Delete-At" => delete_at
           )
@@ -623,25 +654,25 @@ module Backup
       let(:file) { StringIO.new(("a" * segment_bytes) + ("b" * 250)) }
 
       before do
-        cloud_io.stubs(:connection).returns(connection)
+        allow(cloud_io).to receive(:connection).and_return(connection)
       end
 
       it "uploads segments with ETags" do
-        File.expects(:open).with("/src/file", "r").yields(file)
+        expect(File).to receive(:open).with("/src/file", "r").and_yield(file)
 
-        cloud_io.expects(:with_retries)
-          .with("PUT 'my_segments_container/dest/file/0001'").yields
-        connection.expects(:put_object).with(
+        expect(cloud_io).to receive(:with_retries)
+          .with("PUT 'my_segments_container/dest/file/0001'").and_yield
+        expect(connection).to receive(:put_object).with(
           "my_segments_container", "dest/file/0001", nil,
           "ETag" => digest_a
-        ).multiple_yields(nil, nil, nil) # twice to read 2 MiB, third should not read
+        ).and_yield.and_yield.and_yield # twice to read 2 MiB, third should not read
 
-        cloud_io.expects(:with_retries)
-          .with("PUT 'my_segments_container/dest/file/0002'").yields
-        connection.expects(:put_object).with(
+        expect(cloud_io).to receive(:with_retries)
+          .with("PUT 'my_segments_container/dest/file/0002'").and_yield
+        expect(connection).to receive(:put_object).with(
           "my_segments_container", "dest/file/0002", nil,
           "ETag" => digest_b
-        ).multiple_yields(nil, nil) # once to read 250 B, second should not read
+        ).and_yield.and_yield # once to read 250 B, second should not read
 
         expected = [
           { path: "my_segments_container/dest/file/0001",
@@ -665,9 +696,9 @@ module Backup
         segment_bytes = 1024**2 * 1
         file_size = segment_bytes * 100
         file = StringIO.new("x" * file_size)
-        File.expects(:open).with("/src/file", "r").yields(file)
-        cloud_io.stubs(:segment_md5)
-        connection.stubs(:put_object).yields
+        expect(File).to receive(:open).with("/src/file", "r").and_yield(file)
+        allow(cloud_io).to receive(:segment_md5)
+        allow(connection).to receive(:put_object).and_yield
 
         cloud_io.send(:upload_segments,
           "/src/file", "dest/file", segment_bytes, file_size)
@@ -697,17 +728,17 @@ module Backup
         let(:delete_at) { cloud_io.send(:delete_at) }
 
         it "uploads segments with X-Delete-At" do
-          File.expects(:open).with("/src/file", "r").yields(file)
+          expect(File).to receive(:open).with("/src/file", "r").and_yield(file)
 
-          connection.expects(:put_object).with(
+          expect(connection).to receive(:put_object).with(
             "my_segments_container", "dest/file/0001", nil,
             "ETag" => digest_a, "X-Delete-At" => delete_at
-          ).multiple_yields(nil, nil) # twice to read 2 MiB
+          ).and_yield.and_yield # twice to read 2 MiB
 
-          connection.expects(:put_object).with(
+          expect(connection).to receive(:put_object).with(
             "my_segments_container", "dest/file/0002", nil,
             "ETag" => digest_b, "X-Delete-At" => delete_at
-          ).yields # once to read 250 B
+          ).and_yield # once to read 250 B
 
           expected = [
             { path: "my_segments_container/dest/file/0001",
@@ -733,24 +764,30 @@ module Backup
           retry_waitsec: 0
         )
       end
-      let(:segments) { mock }
+      let(:segments) { double }
 
       before do
-        cloud_io.stubs(:connection).returns(connection)
+        allow(cloud_io).to receive(:connection).and_return(connection)
       end
 
       it "uploads manifest with retries" do
-        connection.expects(:put_static_obj_manifest).twice
+        expect(connection).to receive(:put_static_obj_manifest).once
           .with("my_container", "dest/file", segments, {})
-          .raises("error").then.returns(nil)
+          .and_raise("error")
+        expect(connection).to receive(:put_static_obj_manifest).once
+          .with("my_container", "dest/file", segments, {})
+          .and_return(nil)
 
         cloud_io.send(:upload_manifest, "dest/file", segments)
       end
 
       it "fails when retries exceeded" do
-        connection.expects(:put_static_obj_manifest).twice
+        expect(connection).to receive(:put_static_obj_manifest).once
           .with("my_container", "dest/file", segments, {})
-          .raises("error1").then.raises("error2")
+          .and_raise("error1")
+        expect(connection).to receive(:put_static_obj_manifest).once
+          .with("my_container", "dest/file", segments, {})
+          .and_raise("error2")
 
         expect do
           cloud_io.send(:upload_manifest, "dest/file", segments)
@@ -784,7 +821,7 @@ module Backup
         let(:delete_at) { cloud_io.send(:delete_at) }
 
         it "uploads manifest with X-Delete-At" do
-          connection.expects(:put_static_obj_manifest)
+          expect(connection).to receive(:put_static_obj_manifest)
             .with("my_container", "dest/file", segments, "X-Delete-At" => delete_at)
 
           cloud_io.send(:upload_manifest, "dest/file", segments)
@@ -837,32 +874,32 @@ module Backup
 
       describe "#slo?" do
         it "returns true when object is an SLO" do
-          cloud_io.expects(:head_object).once
+          expect(cloud_io).to receive(:head_object).once
             .with(object)
-            .returns(stub(headers: { "X-Static-Large-Object" => "True" }))
+            .and_return(double("response", headers: { "X-Static-Large-Object" => "True" }))
 
           expect(object.slo?).to be(true)
           expect(object.slo?).to be(true)
         end
 
         it "returns false when object is not an SLO" do
-          cloud_io.expects(:head_object).with(object).returns(stub(headers: {}))
+          expect(cloud_io).to receive(:head_object).with(object).and_return(double("response", headers: {}))
           expect(object.slo?).to be(false)
         end
       end
 
       describe "#marked_for_deletion?" do
         it "returns true when object has X-Delete-At set" do
-          cloud_io.expects(:head_object).once
+          expect(cloud_io).to receive(:head_object).once
             .with(object)
-            .returns(stub(headers: { "X-Delete-At" => "12345" }))
+            .and_return(double("response", headers: { "X-Delete-At" => "12345" }))
 
           expect(object.marked_for_deletion?).to be(true)
           expect(object.marked_for_deletion?).to be(true)
         end
 
         it "returns false when object does not have X-Delete-At set" do
-          cloud_io.expects(:head_object).with(object).returns(stub(headers: {}))
+          expect(cloud_io).to receive(:head_object).with(object).and_return(double("response", headers: {}))
           expect(object.marked_for_deletion?).to be(false)
         end
       end

--- a/spec/compressor/base_spec.rb
+++ b/spec/compressor/base_spec.rb
@@ -18,7 +18,7 @@ describe Backup::Compressor::Base do
       compressor.instance_variable_set(:@cmd, "compressor command")
       compressor.instance_variable_set(:@ext, "compressor extension")
 
-      compressor.expects(:log!)
+      expect(compressor).to receive(:log!)
 
       compressor.compress_with do |cmd, ext|
         expect(cmd).to eq("compressor command")
@@ -37,9 +37,9 @@ describe Backup::Compressor::Base do
     it "should log a message" do
       compressor.instance_variable_set(:@cmd, "compressor command")
       compressor.instance_variable_set(:@ext, "compressor extension")
-      compressor.expects(:compressor_name).returns("Compressor Name")
+      expect(compressor).to receive(:compressor_name).and_return("Compressor Name")
 
-      Backup::Logger.expects(:info).with(
+      expect(Backup::Logger).to receive(:info).with(
         "Using Compressor Name for compression.\n" \
         "  Command: 'compressor command'\n" \
         "  Ext: 'compressor extension'"

--- a/spec/compressor/bzip2_spec.rb
+++ b/spec/compressor/bzip2_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Backup::Compressor::Bzip2 do
   before do
-    Backup::Compressor::Bzip2.any_instance.stubs(:utility).returns("bzip2")
+    allow_any_instance_of(Backup::Compressor::Bzip2).to receive(:utility).and_return("bzip2")
   end
 
   it "should be a subclass of Compressor::Base" do
@@ -16,7 +16,7 @@ describe Backup::Compressor::Bzip2 do
     after { Backup::Compressor::Bzip2.clear_defaults! }
 
     it "should load pre-configured defaults" do
-      Backup::Compressor::Bzip2.any_instance.expects(:load_defaults!)
+      expect_any_instance_of(Backup::Compressor::Bzip2).to receive(:load_defaults!)
       compressor
     end
 

--- a/spec/compressor/custom_spec.rb
+++ b/spec/compressor/custom_spec.rb
@@ -23,12 +23,12 @@ describe Backup::Compressor::Custom do
     after { Backup::Compressor::Custom.clear_defaults! }
 
     it "should load pre-configured defaults" do
-      Backup::Compressor::Custom.any_instance.expects(:load_defaults!)
+      expect_any_instance_of(Backup::Compressor::Custom).to receive(:load_defaults!)
       compressor
     end
 
     it "should call Utilities::Helpers#utility to validate command" do
-      Backup::Compressor::Custom.any_instance.expects(:utility)
+      expect_any_instance_of(Backup::Compressor::Custom).to receive(:utility)
       compressor
     end
 
@@ -41,7 +41,7 @@ describe Backup::Compressor::Custom do
       expect(compressor.command).to   eq(" my_command --option foo ")
       expect(compressor.extension).to eq(" my_extension ")
 
-      compressor.expects(:log!)
+      expect(compressor).to receive(:log!)
       compressor.compress_with do |cmd, ext|
         expect(cmd).to eq("/path/to/my_command --option foo")
         expect(ext).to eq("my_extension")

--- a/spec/compressor/gzip_spec.rb
+++ b/spec/compressor/gzip_spec.rb
@@ -2,9 +2,9 @@ require "spec_helper"
 
 describe Backup::Compressor::Gzip do
   before do
-    Backup::Compressor::Gzip.stubs(:utility).returns("gzip")
+    allow(Backup::Compressor::Gzip).to receive(:utility).and_return("gzip")
     Backup::Compressor::Gzip.instance_variable_set(:@has_rsyncable, true)
-    Backup::Compressor::Gzip.any_instance.stubs(:utility).returns("gzip")
+    allow_any_instance_of(Backup::Compressor::Gzip).to receive(:utility).and_return("gzip")
   end
 
   it "should be a subclass of Compressor::Base" do
@@ -24,9 +24,9 @@ describe Backup::Compressor::Gzip do
 
     context "when --rsyncable is available" do
       before do
-        Backup::Compressor::Gzip.expects(:`).once
+        expect(Backup::Compressor::Gzip).to receive(:`).once
           .with("gzip --rsyncable --version >/dev/null 2>&1; echo $?")
-          .returns("0\n")
+          .and_return("0\n")
       end
 
       it "returns true and caches the result" do
@@ -37,9 +37,9 @@ describe Backup::Compressor::Gzip do
 
     context "when --rsyncable is not available" do
       before do
-        Backup::Compressor::Gzip.expects(:`).once
+        expect(Backup::Compressor::Gzip).to receive(:`).once
           .with("gzip --rsyncable --version >/dev/null 2>&1; echo $?")
-          .returns("1\n")
+          .and_return("1\n")
       end
 
       it "returns false and caches the result" do
@@ -116,7 +116,7 @@ describe Backup::Compressor::Gzip do
     it "should ignore rsyncable option and warn user if not supported" do
       Backup::Compressor::Gzip.instance_variable_set(:@has_rsyncable, false)
 
-      Backup::Logger.expects(:warn).with do |err|
+      expect(Backup::Logger).to receive(:warn) do |err|
         expect(err).to be_a(Backup::Compressor::Gzip::Error)
         expect(err.message).to match(/'rsyncable' option ignored/)
       end

--- a/spec/config/helpers_spec.rb
+++ b/spec/config/helpers_spec.rb
@@ -35,10 +35,10 @@ module Backup
     after { Backup.send(:remove_const, "Foo") }
 
     describe ".defaults" do
-      let(:defaults) { mock }
+      let(:defaults) { double }
 
       before do
-        Config::Defaults.expects(:new).once.returns(defaults)
+        expect(Config::Defaults).to receive(:new).once.and_return(defaults)
       end
 
       it "should return the Config::Defaults for the class" do
@@ -121,7 +121,7 @@ module Backup
     describe ".log_deprecation_warning" do
       context "when no message given" do
         it "should log a warning that the attribute has been removed" do
-          Logger.expects(:warn).with do |err|
+          expect(Logger).to receive(:warn) do |err|
             expect(err.message).to eq "Config::Error: [DEPRECATION WARNING]\n" \
               "  Backup::Foo#removed has been deprecated as of backup v.1.1"
           end
@@ -133,7 +133,7 @@ module Backup
 
       context "when a message is given" do
         it "should log warning with the message" do
-          Logger.expects(:warn).with do |err|
+          expect(Logger).to receive(:warn) do |err|
             expect(err.message).to eq "Config::Error: [DEPRECATION WARNING]\n" \
               "  Backup::Foo#removed_with_message has been deprecated " \
               "as of backup v.1.2\n" \
@@ -195,7 +195,7 @@ module Backup
     describe "#method_missing" do
       context "when the method is a deprecated method" do
         before do
-          Logger.expects(:warn).with(instance_of(Config::Error))
+          expect(Logger).to receive(:warn).with(instance_of(Config::Error))
         end
 
         context "when an :action is specified" do
@@ -214,7 +214,7 @@ module Backup
 
         context "when no :action is specified" do
           it "should only log the warning" do
-            Foo.any_instance.expects(:accessor=).never
+            expect_any_instance_of(Foo).to receive(:accessor=).never
 
             klass = Foo.new
             klass.removed = "foo"
@@ -226,7 +226,7 @@ module Backup
 
       context "when the method is not a deprecated method" do
         it "should raise a NoMethodError" do
-          Logger.expects(:warn).never
+          expect(Logger).to receive(:warn).never
 
           klass = Foo.new
           expect do
@@ -237,7 +237,7 @@ module Backup
 
       context "when the method is not a set operation" do
         it "should raise a NoMethodError" do
-          Logger.expects(:warn).never
+          expect(Logger).to receive(:warn).never
 
           klass = Foo.new
           expect do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -9,18 +9,16 @@ module Backup
 
     describe "#load" do
       it "loads config.rb and models" do
-        File.stubs(
-          exist?: true,
-          read: "# Backup v#{major_gem_version}.x Configuration\n@loaded << :config",
-          directory?: true
-        )
-        Dir.stubs(:[] => ["model_a", "model_b"])
-        File.expects(:read).with("model_a").returns("@loaded << :model_a")
-        File.expects(:read).with("model_b").returns("@loaded << :model_b")
+        allow(File).to receive(:exist?).and_return(true)
+        allow(File).to receive(:read).and_return("# Backup v#{major_gem_version}.x Configuration\n@loaded << :config")
+        allow(File).to receive(:directory?).and_return(true)
+        allow(Dir).to receive(:[]).and_return(["model_a", "model_b"])
+        expect(File).to receive(:read).with("model_a").and_return("@loaded << :model_a")
+        expect(File).to receive(:read).with("model_b").and_return("@loaded << :model_b")
 
         dsl = config::DSL.new
         dsl.instance_variable_set(:@loaded, [])
-        config::DSL.stubs(new: dsl)
+        allow(config::DSL).to receive(:new).and_return(dsl)
 
         config.load
 
@@ -37,12 +35,10 @@ module Backup
       end
 
       it "raises an error if config file version is invalid" do
-        File.stubs(
-          exist?: true,
-          read: "# Backup v3.x Configuration",
-          directory?: true
-        )
-        Dir.stubs(:[] => [])
+        allow(File).to receive(:exist?).and_return(true)
+        allow(File).to receive(:read).and_return("# Backup v3.x Configuration")
+        allow(File).to receive(:directory?).and_return(true)
+        allow(Dir).to receive(:[]).and_return([])
 
         expect do
           config.load(config_file: "/foo")
@@ -55,12 +51,10 @@ module Backup
         end
 
         before do
-          File.stubs(
-            exist?: true,
-            read: "# Backup v#{major_gem_version}.x Configuration",
-            directory?: true
-          )
-          Dir.stubs(:[] => [])
+          allow(File).to receive(:exist?).and_return(true)
+          allow(File).to receive(:read).and_return("# Backup v#{major_gem_version}.x Configuration")
+          allow(File).to receive(:directory?).and_return(true)
+          allow(Dir).to receive(:[]).and_return([])
         end
 
         context "when no options are given" do
@@ -98,7 +92,7 @@ module Backup
           end
 
           it "overrides config.rb settings only for the paths given" do
-            config::DSL.any_instance.expects(:_config_options).returns(
+            expect_any_instance_of(config::DSL).to receive(:_config_options).and_return(
               root_path: "/orig/root",
                 tmp_path: "/orig/root/my_tmp",
                 data_path: "/orig/root/my_data"
@@ -137,7 +131,7 @@ module Backup
           end
 
           it "overrides all config.rb settings" do
-            config::DSL.any_instance.expects(:_config_options).returns(
+            expect_any_instance_of(config::DSL).to receive(:_config_options).and_return(
               root_path: "/orig/root",
                 tmp_path: "/orig/root/my_tmp",
                 data_path: "/orig/root/my_data"
@@ -160,11 +154,11 @@ module Backup
     describe "#hostname" do
       before do
         config.instance_variable_set(:@hostname, nil)
-        Utilities.stubs(:utility).with(:hostname).returns("/path/to/hostname")
+        allow(Utilities).to receive(:utility).with(:hostname).and_return("/path/to/hostname")
       end
 
       it "caches the hostname" do
-        Utilities.expects(:run).once.with("/path/to/hostname").returns("my_hostname")
+        expect(Utilities).to receive(:run).once.with("/path/to/hostname").and_return("my_hostname")
         expect(config.hostname).to eq("my_hostname")
         expect(config.hostname).to eq("my_hostname")
       end
@@ -173,7 +167,7 @@ module Backup
     describe "#set_root_path" do
       context "when the given path == @root_path" do
         it "should return @root_path without requiring the path to exist" do
-          File.expects(:directory?).never
+          expect(File).to receive(:directory?).never
           expect(config.send(:set_root_path, config.root_path)).to eq(config.root_path)
         end
       end
@@ -329,7 +323,7 @@ module Backup
         before { ENV["HOME"] = "test/home/dir" }
 
         it "should use #update" do
-          config.expects(:update).with(
+          expect(config).to receive(:update).with(
             root_path: File.join(File.expand_path("test/home/dir"), "Backup")
           )
           config.send(:reset!)

--- a/spec/database/mysql_spec.rb
+++ b/spec/database/mysql_spec.rb
@@ -7,14 +7,14 @@ module Backup
     let(:s) { sequence "" }
 
     before do
-      Database::MySQL.any_instance.stubs(:utility)
-        .with(:mysqldump).returns("mysqldump")
-      Database::MySQL.any_instance.stubs(:utility)
-        .with(:cat).returns("cat")
-      Database::MySQL.any_instance.stubs(:utility)
-        .with(:innobackupex).returns("innobackupex")
-      Database::MySQL.any_instance.stubs(:utility)
-        .with(:tar).returns("tar")
+      allow_any_instance_of(Database::MySQL).to receive(:utility)
+        .with(:mysqldump).and_return("mysqldump")
+      allow_any_instance_of(Database::MySQL).to receive(:utility)
+        .with(:cat).and_return("cat")
+      allow_any_instance_of(Database::MySQL).to receive(:utility)
+        .with(:innobackupex).and_return("innobackupex")
+      allow_any_instance_of(Database::MySQL).to receive(:utility)
+        .with(:tar).and_return("tar")
     end
 
     it_behaves_like "a class that includes Config::Helpers"
@@ -74,31 +74,31 @@ module Backup
     end # describe '#initialize'
 
     describe "#perform!" do
-      let(:pipeline) { mock }
-      let(:compressor) { mock }
+      let(:pipeline) { double }
+      let(:compressor) { double }
 
       before do
-        db.stubs(:mysqldump).returns("mysqldump_command")
-        db.stubs(:dump_path).returns("/tmp/trigger/databases")
+        allow(db).to receive(:mysqldump).and_return("mysqldump_command")
+        allow(db).to receive(:dump_path).and_return("/tmp/trigger/databases")
 
-        db.expects(:log!).in_sequence(s).with(:started)
-        db.expects(:prepare!).in_sequence(s)
+        expect(db).to receive(:log!).ordered.with(:started)
+        expect(db).to receive(:prepare!).ordered
       end
 
       context "without a compressor" do
         it "packages the dump without compression" do
-          Pipeline.expects(:new).in_sequence(s).returns(pipeline)
+          expect(Pipeline).to receive(:new).ordered.and_return(pipeline)
 
-          pipeline.expects(:<<).in_sequence(s).with("mysqldump_command")
+          expect(pipeline).to receive(:<<).ordered.with("mysqldump_command")
 
-          pipeline.expects(:<<).in_sequence(s).with(
+          expect(pipeline).to receive(:<<).ordered.with(
             "cat > '/tmp/trigger/databases/MySQL.sql'"
           )
 
-          pipeline.expects(:run).in_sequence(s)
-          pipeline.expects(:success?).in_sequence(s).returns(true)
+          expect(pipeline).to receive(:run).ordered
+          expect(pipeline).to receive(:success?).ordered.and_return(true)
 
-          db.expects(:log!).in_sequence(s).with(:finished)
+          expect(db).to receive(:log!).ordered.with(:finished)
 
           db.perform!
         end
@@ -106,25 +106,25 @@ module Backup
 
       context "with a compressor" do
         before do
-          model.stubs(:compressor).returns(compressor)
-          compressor.stubs(:compress_with).yields("cmp_cmd", ".cmp_ext")
+          allow(model).to receive(:compressor).and_return(compressor)
+          allow(compressor).to receive(:compress_with).and_yield("cmp_cmd", ".cmp_ext")
         end
 
         it "packages the dump with compression" do
-          Pipeline.expects(:new).in_sequence(s).returns(pipeline)
+          expect(Pipeline).to receive(:new).ordered.and_return(pipeline)
 
-          pipeline.expects(:<<).in_sequence(s).with("mysqldump_command")
+          expect(pipeline).to receive(:<<).ordered.with("mysqldump_command")
 
-          pipeline.expects(:<<).in_sequence(s).with("cmp_cmd")
+          expect(pipeline).to receive(:<<).ordered.with("cmp_cmd")
 
-          pipeline.expects(:<<).in_sequence(s).with(
+          expect(pipeline).to receive(:<<).ordered.with(
             "cat > '/tmp/trigger/databases/MySQL.sql.cmp_ext'"
           )
 
-          pipeline.expects(:run).in_sequence(s)
-          pipeline.expects(:success?).in_sequence(s).returns(true)
+          expect(pipeline).to receive(:run).ordered
+          expect(pipeline).to receive(:success?).ordered.and_return(true)
 
-          db.expects(:log!).in_sequence(s).with(:finished)
+          expect(db).to receive(:log!).ordered.with(:finished)
 
           db.perform!
         end
@@ -132,8 +132,8 @@ module Backup
 
       context "when the pipeline fails" do
         before do
-          Pipeline.any_instance.stubs(:success?).returns(false)
-          Pipeline.any_instance.stubs(:error_messages).returns("error messages")
+          allow_any_instance_of(Pipeline).to receive(:success?).and_return(false)
+          allow_any_instance_of(Pipeline).to receive(:error_messages).and_return("error messages")
         end
 
         it "raises an error" do
@@ -154,31 +154,31 @@ module Backup
       end
 
       describe "#perform!" do
-        let(:pipeline) { mock }
-        let(:compressor) { mock }
+        let(:pipeline) { double }
+        let(:compressor) { double }
 
         before do
-          db.stubs(:innobackupex).returns("innobackupex_command")
-          db.stubs(:dump_path).returns("/tmp/trigger/databases")
+          allow(db).to receive(:innobackupex).and_return("innobackupex_command")
+          allow(db).to receive(:dump_path).and_return("/tmp/trigger/databases")
 
-          db.expects(:log!).in_sequence(s).with(:started)
-          db.expects(:prepare!).in_sequence(s)
+          expect(db).to receive(:log!).ordered.with(:started)
+          expect(db).to receive(:prepare!).ordered
         end
 
         context "without a compressor" do
           it "packages the dump without compression" do
-            Pipeline.expects(:new).in_sequence(s).returns(pipeline)
+            expect(Pipeline).to receive(:new).ordered.and_return(pipeline)
 
-            pipeline.expects(:<<).in_sequence(s).with("innobackupex_command")
+            expect(pipeline).to receive(:<<).ordered.with("innobackupex_command")
 
-            pipeline.expects(:<<).in_sequence(s).with(
+            expect(pipeline).to receive(:<<).ordered.with(
               "cat > '/tmp/trigger/databases/MySQL.tar'"
             )
 
-            pipeline.expects(:run).in_sequence(s)
-            pipeline.expects(:success?).in_sequence(s).returns(true)
+            expect(pipeline).to receive(:run).ordered
+            expect(pipeline).to receive(:success?).ordered.and_return(true)
 
-            db.expects(:log!).in_sequence(s).with(:finished)
+            expect(db).to receive(:log!).ordered.with(:finished)
 
             db.perform!
           end
@@ -186,25 +186,25 @@ module Backup
 
         context "with a compressor" do
           before do
-            model.stubs(:compressor).returns(compressor)
-            compressor.stubs(:compress_with).yields("cmp_cmd", ".cmp_ext")
+            allow(model).to receive(:compressor).and_return(compressor)
+            allow(compressor).to receive(:compress_with).and_yield("cmp_cmd", ".cmp_ext")
           end
 
           it "packages the dump with compression" do
-            Pipeline.expects(:new).in_sequence(s).returns(pipeline)
+            expect(Pipeline).to receive(:new).ordered.and_return(pipeline)
 
-            pipeline.expects(:<<).in_sequence(s).with("innobackupex_command")
+            expect(pipeline).to receive(:<<).ordered.with("innobackupex_command")
 
-            pipeline.expects(:<<).in_sequence(s).with("cmp_cmd")
+            expect(pipeline).to receive(:<<).ordered.with("cmp_cmd")
 
-            pipeline.expects(:<<).in_sequence(s).with(
+            expect(pipeline).to receive(:<<).ordered.with(
               "cat > '/tmp/trigger/databases/MySQL.tar.cmp_ext'"
             )
 
-            pipeline.expects(:run).in_sequence(s)
-            pipeline.expects(:success?).in_sequence(s).returns(true)
+            expect(pipeline).to receive(:run).ordered
+            expect(pipeline).to receive(:success?).ordered.and_return(true)
 
-            db.expects(:log!).in_sequence(s).with(:finished)
+            expect(db).to receive(:log!).ordered.with(:finished)
 
             db.perform!
           end
@@ -212,8 +212,8 @@ module Backup
 
         context "when the pipeline fails" do
           before do
-            Pipeline.any_instance.stubs(:success?).returns(false)
-            Pipeline.any_instance.stubs(:error_messages).returns("error messages")
+            allow_any_instance_of(Pipeline).to receive(:success?).and_return(false)
+            allow_any_instance_of(Pipeline).to receive(:error_messages).and_return("error messages")
           end
 
           it "raises an error" do
@@ -238,14 +238,14 @@ module Backup
       end
 
       it "returns full mysqldump command built from all options" do
-        option_methods.each { |name| db.stubs(name).returns(name) }
+        option_methods.each { |name| allow(db).to receive(name).and_return(name) }
         expect(db.send(:mysqldump)).to eq(
           "mysqldump #{option_methods.join(" ")}"
         )
       end
 
       it "handles nil values from option methods" do
-        option_methods.each { |name| db.stubs(name).returns(nil) }
+        option_methods.each { |name| allow(db).to receive(name).and_return(nil) }
         expect(db.send(:mysqldump)).to eq(
           "mysqldump #{" " * (option_methods.count - 1)}"
         )
@@ -415,7 +415,7 @@ module Backup
 
     describe "#innobackupex" do
       before do
-        db.stubs(:dump_path).returns("/tmp")
+        allow(db).to receive(:dump_path).and_return("/tmp")
       end
 
       it "builds command to create backup, prepare for restore and tar to stdout" do

--- a/spec/encryptor/base_spec.rb
+++ b/spec/encryptor/base_spec.rb
@@ -15,7 +15,7 @@ describe Backup::Encryptor::Base do
 
   describe "#initialize" do
     it "should load defaults" do
-      Backup::Encryptor::Base.any_instance.expects(:load_defaults!)
+      expect_any_instance_of(Backup::Encryptor::Base).to receive(:load_defaults!)
       base
     end
   end
@@ -28,8 +28,8 @@ describe Backup::Encryptor::Base do
 
   describe "#log!" do
     it "should log a message" do
-      base.expects(:encryptor_name).returns("Encryptor Name")
-      Backup::Logger.expects(:info).with(
+      expect(base).to receive(:encryptor_name).and_return("Encryptor Name")
+      expect(Backup::Logger).to receive(:info).with(
         "Using Encryptor Name to encrypt the archive."
       )
       base.send(:log!)

--- a/spec/encryptor/open_ssl_spec.rb
+++ b/spec/encryptor/open_ssl_spec.rb
@@ -19,7 +19,7 @@ describe Backup::Encryptor::OpenSSL do
     after { Backup::Encryptor::OpenSSL.clear_defaults! }
 
     it "should load pre-configured defaults" do
-      Backup::Encryptor::OpenSSL.any_instance.expects(:load_defaults!)
+      expect_any_instance_of(Backup::Encryptor::OpenSSL).to receive(:load_defaults!)
       encryptor
     end
 
@@ -69,9 +69,9 @@ describe Backup::Encryptor::OpenSSL do
 
   describe "#encrypt_with" do
     it "should yield the encryption command and extension" do
-      encryptor.expects(:log!)
-      encryptor.expects(:utility).with(:openssl).returns("openssl_cmd")
-      encryptor.expects(:options).returns("cmd_options")
+      expect(encryptor).to receive(:log!)
+      expect(encryptor).to receive(:utility).with(:openssl).and_return("openssl_cmd")
+      expect(encryptor).to receive(:options).and_return("cmd_options")
 
       encryptor.encrypt_with do |command, ext|
         expect(command).to eq("openssl_cmd cmd_options")

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -295,9 +295,9 @@ module Backup
       context "with a wrapped exception" do
         describe ".wrap" do
           it "wraps #initialize to reverse parameters" do
-            ex = mock
-            described_class.expects(:new).with(nil, ex)
-            described_class.expects(:new).with("error message", ex)
+            ex = double
+            expect(described_class).to receive(:new).with(nil, ex)
+            expect(described_class).to receive(:new).with("error message", ex)
 
             described_class.wrap(ex)
             described_class.wrap(ex, "error message")

--- a/spec/logger/console_spec.rb
+++ b/spec/logger/console_spec.rb
@@ -5,8 +5,8 @@ module Backup
     let(:timestamp) { Time.now.utc.strftime("%Y/%m/%d %H:%M:%S") }
 
     before do
-      Logger::Logfile.any_instance.expects(:log).never
-      Logger::Syslog.any_instance.expects(:log).never
+      expect_any_instance_of(Logger::Logfile).to receive(:log).never
+      expect_any_instance_of(Logger::Syslog).to receive(:log).never
       Logger.configure do
         logfile.enabled = false
         syslog.enabled = false
@@ -21,7 +21,7 @@ module Backup
         end
         Logger.start!
 
-        Logger::Console.any_instance.expects(:log).never
+        expect_any_instance_of(Logger::Console).to receive(:log).never
         Logger.info "message"
       end
 
@@ -36,7 +36,7 @@ module Backup
         end
         Logger.start!
 
-        Logger::Console.any_instance.expects(:log)
+        expect_any_instance_of(Logger::Console).to receive(:log)
         Logger.info "message"
       end
     end
@@ -46,14 +46,14 @@ module Backup
 
       context "when IO is attached to a terminal" do
         before do
-          $stdout.stubs(:tty?).returns(true)
-          $stderr.stubs(:tty?).returns(true)
+          allow($stdout).to receive(:tty?).and_return(true)
+          allow($stderr).to receive(:tty?).and_return(true)
         end
 
         it "sends colorized, formatted :info message to $stdout" do
-          $stderr.expects(:puts).never
+          expect($stderr).to receive(:puts).never
           Timecop.freeze do
-            $stdout.expects(:puts).with([
+            expect($stdout).to receive(:puts).with([
               "\e[32m[#{timestamp}][info] message line one\e[0m",
               "\e[32m[#{timestamp}][info] message line two\e[0m"
             ])
@@ -62,9 +62,9 @@ module Backup
         end
 
         it "sends colorized, formatted :warn message to $stderr" do
-          $stdout.expects(:puts).never
+          expect($stdout).to receive(:puts).never
           Timecop.freeze do
-            $stderr.expects(:puts).with([
+            expect($stderr).to receive(:puts).with([
               "\e[33m[#{timestamp}][warn] message line one\e[0m",
               "\e[33m[#{timestamp}][warn] message line two\e[0m"
             ])
@@ -73,9 +73,9 @@ module Backup
         end
 
         it "sends colorized, formatted :error message to $stderr" do
-          $stdout.expects(:puts).never
+          expect($stdout).to receive(:puts).never
           Timecop.freeze do
-            $stderr.expects(:puts).with([
+            expect($stderr).to receive(:puts).with([
               "\e[31m[#{timestamp}][error] message line one\e[0m",
               "\e[31m[#{timestamp}][error] message line two\e[0m"
             ])
@@ -86,14 +86,14 @@ module Backup
 
       context "when IO is not attached to a terminal" do
         before do
-          $stdout.stubs(:tty?).returns(false)
-          $stderr.stubs(:tty?).returns(false)
+          allow($stdout).to receive(:tty?).and_return(false)
+          allow($stderr).to receive(:tty?).and_return(false)
         end
 
         it "sends non-colorized, formatted :info message to $stdout" do
-          $stderr.expects(:puts).never
+          expect($stderr).to receive(:puts).never
           Timecop.freeze do
-            $stdout.expects(:puts).with([
+            expect($stdout).to receive(:puts).with([
               "[#{timestamp}][info] message line one",
               "[#{timestamp}][info] message line two"
             ])
@@ -102,9 +102,9 @@ module Backup
         end
 
         it "sends non-colorized, formatted :warn message to $stderr" do
-          $stdout.expects(:puts).never
+          expect($stdout).to receive(:puts).never
           Timecop.freeze do
-            $stderr.expects(:puts).with([
+            expect($stderr).to receive(:puts).with([
               "[#{timestamp}][warn] message line one",
               "[#{timestamp}][warn] message line two"
             ])
@@ -113,9 +113,9 @@ module Backup
         end
 
         it "sends non-colorized, formatted :error message to $stderr" do
-          $stdout.expects(:puts).never
+          expect($stdout).to receive(:puts).never
           Timecop.freeze do
-            $stderr.expects(:puts).with([
+            expect($stderr).to receive(:puts).with([
               "[#{timestamp}][error] message line one",
               "[#{timestamp}][error] message line two"
             ])

--- a/spec/logger/fog_adapter_spec.rb
+++ b/spec/logger/fog_adapter_spec.rb
@@ -14,7 +14,7 @@ module Backup
 
     describe "#write" do
       it "logs fog warnings as info messages" do
-        Logger.expects(:info).with("[fog][WARNING] some message")
+        expect(Logger).to receive(:info).with("[fog][WARNING] some message")
         Fog::Logger.warning "some message"
       end
     end

--- a/spec/logger/logfile_spec.rb
+++ b/spec/logger/logfile_spec.rb
@@ -13,10 +13,10 @@ module Backup
       @log_path_default = File.join(@root_path, "log")
       @logfile_default = File.join(@log_path_default, "backup.log")
 
-      Backup::Config.stubs(:root_path).returns(@root_path)
+      allow(Backup::Config).to receive(:root_path).and_return(@root_path)
 
-      Logger::Console.any_instance.expects(:log).never
-      Logger::Syslog.any_instance.expects(:log).never
+      expect_any_instance_of(Logger::Console).to receive(:log).never
+      expect_any_instance_of(Logger::Syslog).to receive(:log).never
       Logger.configure do
         console.quiet = true
         logfile.enabled = true
@@ -35,7 +35,7 @@ module Backup
         end
         Logger.start!
 
-        Logger::Syslog.any_instance.expects(:log).never
+        expect_any_instance_of(Logger::Syslog).to receive(:log).never
         Logger.info "message"
         expect(File.exist?(@log_path_default)).to eq(false)
       end
@@ -51,7 +51,7 @@ module Backup
         end
         Logger.start!
 
-        Logger::Syslog.any_instance.expects(:log).never
+        expect_any_instance_of(Logger::Syslog).to receive(:log).never
         Logger.info "message"
         expect(File.exist?(@log_path_default)).to eq(false)
       end
@@ -151,7 +151,7 @@ module Backup
 
         context "when log file is not larger than max_bytes" do
           it "does not truncates the file" do
-            File.expects(:mv).never
+            expect(File).to receive(:mv).never
             Logger.start!
             Logger.info "a message"
 
@@ -164,7 +164,7 @@ module Backup
 
         context "when log file does not exist" do
           it "does not truncates the file" do
-            File.expects(:mv).never
+            expect(File).to receive(:mv).never
             Logger.start!
             expect(File.exist?(@log_path_default)).to eq(true)
             expect(File.exist?(@logfile_default)).to eq(false)

--- a/spec/logger/syslog_spec.rb
+++ b/spec/logger/syslog_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 module Backup
   describe Logger::Syslog do
     before do
-      Logger::Console.any_instance.expects(:log).never
-      Logger::Logfile.any_instance.expects(:log).never
+      expect_any_instance_of(Logger::Console).to receive(:log).never
+      expect_any_instance_of(Logger::Logfile).to receive(:log).never
       Logger.configure do
         console.quiet = true
         logfile.enabled = false
@@ -19,7 +19,7 @@ module Backup
         end
         Logger.start!
 
-        Logger::Syslog.any_instance.expects(:log).never
+        expect_any_instance_of(Logger::Syslog).to receive(:log).never
         Logger.info "message"
       end
 
@@ -34,13 +34,13 @@ module Backup
         end
         Logger.start!
 
-        Logger::Syslog.any_instance.expects(:log).never
+        expect_any_instance_of(Logger::Syslog).to receive(:log).never
         Logger.info "message"
       end
     end
 
     describe "console logger usage" do
-      let(:syslog_logger) { mock }
+      let(:syslog_logger) { double }
       let(:s) { sequence "" }
 
       before do
@@ -49,19 +49,19 @@ module Backup
           syslog.facility = ::Syslog::LOG_LOCAL4
         end
 
-        ::Syslog.expects(:open).with(
+        expect(::Syslog).to receive(:open).with(
           "test ident", ::Syslog::LOG_PID, ::Syslog::LOG_LOCAL4
-        ).yields(syslog_logger)
+        ).and_yield(syslog_logger)
 
         Logger.start!
       end
 
       context "when sending an :info message" do
         it "sends info messages to syslog" do
-          syslog_logger.expects(:log).in_sequence(s).with(
+          expect(syslog_logger).to receive(:log).ordered.with(
             ::Syslog::LOG_INFO, "%s", "message line one"
           )
-          syslog_logger.expects(:log).in_sequence(s).with(
+          expect(syslog_logger).to receive(:log).ordered.with(
             ::Syslog::LOG_INFO, "%s", "message line two"
           )
           Logger.info "message line one\nmessage line two"
@@ -70,10 +70,10 @@ module Backup
 
       context "when sending an :warn message" do
         it "sends warn messages to syslog" do
-          syslog_logger.expects(:log).in_sequence(s).with(
+          expect(syslog_logger).to receive(:log).ordered.with(
             ::Syslog::LOG_WARNING, "%s", "message line one"
           )
-          syslog_logger.expects(:log).in_sequence(s).with(
+          expect(syslog_logger).to receive(:log).ordered.with(
             ::Syslog::LOG_WARNING, "%s", "message line two"
           )
           Logger.warn "message line one\nmessage line two"
@@ -82,10 +82,10 @@ module Backup
 
       context "when sending an :error message" do
         it "sends error messages to syslog" do
-          syslog_logger.expects(:log).in_sequence(s).with(
+          expect(syslog_logger).to receive(:log).ordered.with(
             ::Syslog::LOG_ERR, "%s", "message line one"
           )
-          syslog_logger.expects(:log).in_sequence(s).with(
+          expect(syslog_logger).to receive(:log).ordered.with(
             ::Syslog::LOG_ERR, "%s", "message line two"
           )
           Logger.error "message line one\nmessage line two"

--- a/spec/notifier/campfire_spec.rb
+++ b/spec/notifier/campfire_spec.rb
@@ -65,7 +65,7 @@ module Backup
 
       context "when status is :success" do
         it "sends a success message" do
-          Excon.expects(:post).with(
+          expect(Excon).to receive(:post).with(
             "https://my_subdomain.campfirenow.com/room/my_room_id/speak.json",
             headers: { "Content-Type" => "application/json" },
             body: json_body.sub("STATUS", "Success"),
@@ -80,7 +80,7 @@ module Backup
 
       context "when status is :warning" do
         it "sends a warning message" do
-          Excon.expects(:post).with(
+          expect(Excon).to receive(:post).with(
             "https://my_subdomain.campfirenow.com/room/my_room_id/speak.json",
             headers: { "Content-Type" => "application/json" },
             body: json_body.sub("STATUS", "Warning"),
@@ -95,7 +95,7 @@ module Backup
 
       context "when status is :failure" do
         it "sends a failure message" do
-          Excon.expects(:post).with(
+          expect(Excon).to receive(:post).with(
             "https://my_subdomain.campfirenow.com/room/my_room_id/speak.json",
             headers: { "Content-Type" => "application/json" },
             body: json_body.sub("STATUS", "Failure"),

--- a/spec/notifier/command_notifier_spec.rb
+++ b/spec/notifier/command_notifier_spec.rb
@@ -34,7 +34,7 @@ module Backup
     describe "#notify!" do
       context "when status is :success" do
         it "sends a success message" do
-          IO.expects(:popen).with(
+          expect(IO).to receive(:popen).with(
             [
               "notify-send",
               "TEST LABEL",
@@ -48,7 +48,7 @@ module Backup
 
       context "when status is :warning" do
         it "sends a warning message" do
-          IO.expects(:popen).with(
+          expect(IO).to receive(:popen).with(
             [
               "notify-send",
               "TEST LABEL",
@@ -62,7 +62,7 @@ module Backup
 
       context "when status is :failure" do
         it "sends a failure message" do
-          IO.expects(:popen).with(
+          expect(IO).to receive(:popen).with(
             [
               "notify-send",
               "TEST LABEL",

--- a/spec/notifier/datadog_spec.rb
+++ b/spec/notifier/datadog_spec.rb
@@ -68,20 +68,20 @@ module Backup
           datadog.api_key = "my_token"
         end
       end
-      let(:client) { mock }
-      let(:event) { mock }
+      let(:client) { double }
+      let(:event) { double }
 
       context "when status is :success" do
         it "sends a success message" do
-          Dogapi::Client.expects(:new).in_sequence(s)
+          expect(Dogapi::Client).to receive(:new).ordered
             .with("my_token")
-            .returns(client)
-          Dogapi::Event.expects(:new).in_sequence(s).with(
+            .and_return(client)
+          expect(Dogapi::Event).to receive(:new).ordered.with(
             "[Backup::Success] test label (test_trigger)",
             msg_title: "Backup test label",
             alert_type: "success"
-          ).returns(event)
-          client.expects(:emit_event).in_sequence(s).with(event)
+          ).and_return(event)
+          expect(client).to receive(:emit_event).ordered.with(event)
 
           notifier.send(:notify!, :success)
         end
@@ -89,15 +89,15 @@ module Backup
 
       context "when status is :warning" do
         it "sends a warning message" do
-          Dogapi::Client.expects(:new).in_sequence(s)
+          expect(Dogapi::Client).to receive(:new).ordered
             .with("my_token")
-            .returns(client)
-          Dogapi::Event.expects(:new).in_sequence(s).with(
+            .and_return(client)
+          expect(Dogapi::Event).to receive(:new).ordered.with(
             "[Backup::Warning] test label (test_trigger)",
             msg_title: "Backup test label",
             alert_type: "warning"
-          ).returns(event)
-          client.expects(:emit_event).in_sequence(s).with(event)
+          ).and_return(event)
+          expect(client).to receive(:emit_event).ordered.with(event)
 
           notifier.send(:notify!, :warning)
         end
@@ -105,15 +105,15 @@ module Backup
 
       context "when status is :failure" do
         it "sends an error message" do
-          Dogapi::Client.expects(:new).in_sequence(s)
+          expect(Dogapi::Client).to receive(:new).ordered
             .with("my_token")
-            .returns(client)
-          Dogapi::Event.expects(:new).in_sequence(s).with(
+            .and_return(client)
+          expect(Dogapi::Event).to receive(:new).ordered.with(
             "[Backup::Failure] test label (test_trigger)",
             msg_title: "Backup test label",
             alert_type: "error"
-          ).returns(event)
-          client.expects(:emit_event).in_sequence(s).with(event)
+          ).and_return(event)
+          expect(client).to receive(:emit_event).ordered.with(event)
 
           notifier.send(:notify!, :failure)
         end

--- a/spec/notifier/flowdock_spec.rb
+++ b/spec/notifier/flowdock_spec.rb
@@ -62,17 +62,17 @@ module Backup
           flowdock.link            = "www.example.com"
         end
       end
-      let(:client) { mock }
+      let(:client) { double }
       let(:push_to_team_inbox) { double }
       let(:message) { "[Backup::%s] test label (test_trigger)" }
 
       context "when status is :success" do
         it "sends a success message" do
-          Flowdock::Flow.expects(:new).in_sequence(s).with(
+          expect(Flowdock::Flow).to receive(:new).ordered.with(
             api_token: "my_token", source: "Backup test label",
             from: { name: "my_name", address: "email@example.com" }
-          ).returns(client)
-          client.expects(:push_to_team_inbox).in_sequence(s).with(
+          ).and_return(client)
+          expect(client).to receive(:push_to_team_inbox).ordered.with(
             subject: "My Daily Backup",
             content: message % "Success",
             tags: ["prod", "#BackupSuccess"],
@@ -85,11 +85,11 @@ module Backup
 
       context "when status is :warning" do
         it "sends a warning message" do
-          Flowdock::Flow.expects(:new).in_sequence(s).with(
+          expect(Flowdock::Flow).to receive(:new).ordered.with(
             api_token: "my_token", source: "Backup test label",
             from: { name: "my_name", address: "email@example.com" }
-          ).returns(client)
-          client.expects(:push_to_team_inbox).in_sequence(s).with(
+          ).and_return(client)
+          expect(client).to receive(:push_to_team_inbox).ordered.with(
             subject: "My Daily Backup",
             content: message % "Warning",
             tags: ["prod", "#BackupWarning"],
@@ -102,11 +102,11 @@ module Backup
 
       context "when status is :failure" do
         it "sends a failure message" do
-          Flowdock::Flow.expects(:new).in_sequence(s).with(
+          expect(Flowdock::Flow).to receive(:new).ordered.with(
             api_token: "my_token", source: "Backup test label",
             from: { name: "my_name", address: "email@example.com" }
-          ).returns(client)
-          client.expects(:push_to_team_inbox).in_sequence(s).with(
+          ).and_return(client)
+          expect(client).to receive(:push_to_team_inbox).ordered.with(
             subject: "My Daily Backup",
             content: message % "Failure",
             tags: ["prod", "#BackupFailure"],

--- a/spec/notifier/hipchat_spec.rb
+++ b/spec/notifier/hipchat_spec.rb
@@ -79,23 +79,23 @@ module Backup
       let(:client_options) do
         { api_version: "v1", server_url: "https://mycustom.server.com" }
       end
-      let(:client) { mock }
-      let(:room) { mock }
+      let(:client) { double }
+      let(:room) { double }
       let(:message) { "[Backup::%s] test label (test_trigger)" }
 
       context "when status is :success" do
         it "sends a success message" do
-          HipChat::Client.expects(:new).in_sequence(s)
+          expect(HipChat::Client).to receive(:new).ordered
             .with("my_token", client_options)
-            .returns(client)
-          client.expects(:[]).in_sequence(s).with("room_a").returns(room)
-          room.expects(:send).in_sequence(s).with(
+            .and_return(client)
+          expect(client).to receive(:[]).ordered.with("room_a").and_return(room)
+          expect(room).to receive(:send).ordered.with(
             "my_from", message % "Success",
             color: :success_color,
             notify: true
           )
-          client.expects(:[]).in_sequence(s).with("room_b").returns(room)
-          room.expects(:send).in_sequence(s).with(
+          expect(client).to receive(:[]).ordered.with("room_b").and_return(room)
+          expect(room).to receive(:send).ordered.with(
             "my_from",
             message % "Success",
             color: :success_color, notify: true
@@ -107,18 +107,18 @@ module Backup
 
       context "when status is :warning" do
         it "sends a warning message" do
-          HipChat::Client.expects(:new).in_sequence(s)
+          expect(HipChat::Client).to receive(:new).ordered
             .with("my_token", client_options)
-            .returns(client)
-          client.expects(:[]).in_sequence(s).with("room_a").returns(room)
-          room.expects(:send).in_sequence(s).with(
+            .and_return(client)
+          expect(client).to receive(:[]).ordered.with("room_a").and_return(room)
+          expect(room).to receive(:send).ordered.with(
             "my_from",
             message % "Warning",
             color: :warning_color,
             notify: true
           )
-          client.expects(:[]).in_sequence(s).with("room_b").returns(room)
-          room.expects(:send).in_sequence(s).with(
+          expect(client).to receive(:[]).ordered.with("room_b").and_return(room)
+          expect(room).to receive(:send).ordered.with(
             "my_from",
             message % "Warning",
             color: :warning_color,
@@ -131,18 +131,18 @@ module Backup
 
       context "when status is :failure" do
         it "sends a failure message" do
-          HipChat::Client.expects(:new).in_sequence(s)
+          expect(HipChat::Client).to receive(:new).ordered
             .with("my_token", client_options)
-            .returns(client)
-          client.expects(:[]).in_sequence(s).with("room_a").returns(room)
-          room.expects(:send).in_sequence(s).with(
+            .and_return(client)
+          expect(client).to receive(:[]).ordered.with("room_a").and_return(room)
+          expect(room).to receive(:send).ordered.with(
             "my_from",
             message % "Failure",
             color: :failure_color,
             notify: true
           )
-          client.expects(:[]).in_sequence(s).with("room_b").returns(room)
-          room.expects(:send).in_sequence(s).with(
+          expect(client).to receive(:[]).ordered.with("room_b").and_return(room)
+          expect(room).to receive(:send).ordered.with(
             "my_from",
             message % "Failure",
             color: :failure_color,

--- a/spec/notifier/http_post_spec.rb
+++ b/spec/notifier/http_post_spec.rb
@@ -73,7 +73,7 @@ module Backup
       it "defines additional headers to be sent" do
         notifier.headers = { "Authorization" => "my_auth" }
 
-        Excon.expects(:post).with(
+        expect(Excon).to receive(:post).with(
           "https://www.example.com/path",
           headers: { "User-Agent" => "Backup/#{VERSION}",
                      "Content-Type" => "application/x-www-form-urlencoded",
@@ -88,7 +88,7 @@ expects: 200
       it "may overrided the User-Agent header" do
         notifier.headers = { "Authorization" => "my_auth", "User-Agent" => "my_app" }
 
-        Excon.expects(:post).with(
+        expect(Excon).to receive(:post).with(
           "https://www.example.com/path",
           headers: { "User-Agent" => "my_app",
                      "Content-Type" => "application/x-www-form-urlencoded",
@@ -103,7 +103,7 @@ expects: 200
       it "may omit the User-Agent header" do
         notifier.headers = { "Authorization" => "my_auth", "User-Agent" => nil }
 
-        Excon.expects(:post).with(
+        expect(Excon).to receive(:post).with(
           "https://www.example.com/path",
           headers: { "Content-Type" => "application/x-www-form-urlencoded",
                      "Authorization" => "my_auth" },
@@ -121,7 +121,7 @@ expects: 200
         form_data = "message=%5BBackup%3A%3ASuccess%5D+test+label+%28test_trigger%29" \
             "&my_param=my_value&status=success"
 
-        Excon.expects(:post).with(
+        expect(Excon).to receive(:post).with(
           "https://www.example.com/path",
           headers: default_headers,
 body: form_data,
@@ -135,7 +135,7 @@ expects: 200
         notifier.params = { "my_param" => "my_value", "message" => "my message" }
         form_data = "message=my+message&my_param=my_value&status=success"
 
-        Excon.expects(:post).with(
+        expect(Excon).to receive(:post).with(
           "https://www.example.com/path",
           headers: default_headers,
 body: form_data,
@@ -149,7 +149,7 @@ expects: 200
         notifier.params = { "my_param" => "my_value", "message" => nil }
         form_data = "my_param=my_value&status=success"
 
-        Excon.expects(:post).with(
+        expect(Excon).to receive(:post).with(
           "https://www.example.com/path",
           headers: default_headers,
 body: form_data,
@@ -164,7 +164,7 @@ expects: 200
       it "specifies expected http success codes" do
         notifier.success_codes = [200, 201]
 
-        Excon.expects(:post).with(
+        expect(Excon).to receive(:post).with(
           "https://www.example.com/path",
           headers: default_headers,
 body: default_form_data,
@@ -179,7 +179,7 @@ expects: [200, 201]
       it "may force enable verification" do
         notifier.ssl_verify_peer = true
 
-        Excon.expects(:post).with(
+        expect(Excon).to receive(:post).with(
           "https://www.example.com/path",
           headers: default_headers,
 body: default_form_data,
@@ -193,7 +193,7 @@ ssl_verify_peer: true
       it "may disable verification" do
         notifier.ssl_verify_peer = false
 
-        Excon.expects(:post).with(
+        expect(Excon).to receive(:post).with(
           "https://www.example.com/path",
           headers: default_headers,
 body: default_form_data,
@@ -209,7 +209,7 @@ ssl_verify_peer: false
       it "specifies path to a custom cacert.pem file" do
         notifier.ssl_ca_file = "/my/cacert.pem"
 
-        Excon.expects(:post).with(
+        expect(Excon).to receive(:post).with(
           "https://www.example.com/path",
           headers: default_headers,
 body: default_form_data,
@@ -229,7 +229,7 @@ ssl_ca_file: "/my/cacert.pem"
 
       context "when status is :success" do
         it "sends a success message" do
-          Excon.expects(:post).with(
+          expect(Excon).to receive(:post).with(
             "https://www.example.com/path",
             headers: default_headers,
 body: form_data.sub("TAG", "Success").sub("STATUS", "success"),
@@ -242,7 +242,7 @@ expects: 200
 
       context "when status is :warning" do
         it "sends a warning message" do
-          Excon.expects(:post).with(
+          expect(Excon).to receive(:post).with(
             "https://www.example.com/path",
             headers: default_headers,
 body: form_data.sub("TAG", "Warning").sub("STATUS", "warning"),
@@ -255,7 +255,7 @@ expects: 200
 
       context "when status is :failure" do
         it "sends a failure message" do
-          Excon.expects(:post).with(
+          expect(Excon).to receive(:post).with(
             "https://www.example.com/path",
             headers: default_headers,
 body: form_data.sub("TAG", "Failure").sub("STATUS", "failure"),

--- a/spec/notifier/mail_spec.rb
+++ b/spec/notifier/mail_spec.rb
@@ -6,10 +6,10 @@ module Backup
     let(:notifier) { Notifier::Mail.new(model) }
 
     before do
-      Notifier::Mail.any_instance.stubs(:utility)
-        .with(:sendmail).returns("/path/to/sendmail")
-      Notifier::Mail.any_instance.stubs(:utility)
-        .with(:exim).returns("/path/to/exim")
+      allow_any_instance_of(Notifier::Mail).to receive(:utility)
+        .with(:sendmail).and_return("/path/to/sendmail")
+      allow_any_instance_of(Notifier::Mail).to receive(:utility)
+        .with(:exim).and_return("/path/to/exim")
     end
 
     it_behaves_like "a class that includes Config::Helpers"
@@ -108,15 +108,15 @@ module Backup
 
         ::Mail::TestMailer.deliveries.clear
 
-        Logger.stubs(:messages).returns([
-          stub(formatted_lines: ["line 1", "line 2"]),
-          stub(formatted_lines: ["line 3"])
+        allow(Logger).to receive(:messages).and_return([
+          double(Logger::Message, formatted_lines: ["line 1", "line 2"]),
+          double(Logger::Message, formatted_lines: ["line 3"])
         ])
 
         time = Time.now
-        model.stubs(:time).returns(time.strftime("%Y.%m.%d.%H.%M.%S"))
-        model.stubs(:started_at).returns(time)
-        model.stubs(:finished_at).returns(time + 5)
+        allow(model).to receive(:time).and_return(time.strftime("%Y.%m.%d.%H.%M.%S"))
+        allow(model).to receive(:started_at).and_return(time)
+        allow(model).to receive(:finished_at).and_return(time + 5)
       end
 
       context "when status is :success" do

--- a/spec/notifier/nagios_spec.rb
+++ b/spec/notifier/nagios_spec.rb
@@ -6,8 +6,8 @@ module Backup
     let(:notifier) { Notifier::Nagios.new(model) }
 
     before do
-      Utilities.stubs(:utility).with(:send_nsca).returns("send_nsca")
-      Config.stubs(:hostname).returns("my.hostname")
+      allow(Utilities).to receive(:utility).with(:send_nsca).and_return("send_nsca")
+      allow(Config).to receive(:hostname).and_return("my.hostname")
     end
 
     it_behaves_like "a class that includes Config::Helpers"
@@ -62,7 +62,7 @@ module Backup
 
       before do
         notifier.service_host = "my.service.host"
-        model.stubs(:duration).returns("12:34:56")
+        allow(model).to receive(:duration).and_return("12:34:56")
       end
 
       context "when status is :success" do
@@ -70,10 +70,10 @@ module Backup
           "my.service.host\tBackup test_trigger\t0\t"\
           "[Backup::Success] test model (test_trigger)"
         end
-        before { model.stubs(:exit_status).returns(0) }
+        before { allow(model).to receive(:exit_status).and_return(0) }
 
         it "sends a Success message" do
-          Utilities.expects(:run).with("echo '#{nagios_msg}' | #{nagios_cmd}")
+          expect(Utilities).to receive(:run).with("echo '#{nagios_msg}' | #{nagios_cmd}")
 
           notifier.send(:notify!, :success)
         end
@@ -84,10 +84,10 @@ module Backup
           "my.service.host\tBackup test_trigger\t1\t"\
           "[Backup::Warning] test model (test_trigger)"
         end
-        before { model.stubs(:exit_status).returns(1) }
+        before { allow(model).to receive(:exit_status).and_return(1) }
 
         it "sends a Success message" do
-          Utilities.expects(:run).with("echo '#{nagios_msg}' | #{nagios_cmd}")
+          expect(Utilities).to receive(:run).with("echo '#{nagios_msg}' | #{nagios_cmd}")
 
           notifier.send(:notify!, :warning)
         end
@@ -98,10 +98,10 @@ module Backup
           "my.service.host\tBackup test_trigger\t2\t"\
           "[Backup::Failure] test model (test_trigger)"
         end
-        before { model.stubs(:exit_status).returns(2) }
+        before { allow(model).to receive(:exit_status).and_return(2) }
 
         it "sends a Success message" do
-          Utilities.expects(:run).with("echo '#{nagios_msg}' | #{nagios_cmd}")
+          expect(Utilities).to receive(:run).with("echo '#{nagios_msg}' | #{nagios_cmd}")
 
           notifier.send(:notify!, :failure)
         end

--- a/spec/notifier/pagerduty_spec.rb
+++ b/spec/notifier/pagerduty_spec.rb
@@ -21,8 +21,8 @@ module Backup
     end
 
     describe "notify!" do
-      let(:pagerduty) { mock }
-      let(:incident) { mock }
+      let(:pagerduty) { double }
+      let(:incident) { double }
 
       let(:incident_key) { "backup/test_trigger" }
       let(:incident_details) do
@@ -40,21 +40,21 @@ module Backup
       end
 
       before do
-        notifier.stubs(:pagerduty).returns(pagerduty)
+        allow(notifier).to receive(:pagerduty).and_return(pagerduty)
       end
 
       it "resolves an incident when status is :success" do
         incident_details[:details][:status] = :success
 
-        pagerduty.expects(:get_incident).with(incident_key).returns(incident)
-        incident.expects(:resolve).with("Backup - test label", incident_details)
+        expect(pagerduty).to receive(:get_incident).with(incident_key).and_return(incident)
+        expect(incident).to receive(:resolve).with("Backup - test label", incident_details)
 
         notifier.send(:notify!, :success)
       end
 
       it "triggers an incident when status is :warning and resolve_on_warning is false" do
         incident_details[:details][:status] = :warning
-        pagerduty.expects(:trigger).with("Backup - test label", incident_details)
+        expect(pagerduty).to receive(:trigger).with("Backup - test label", incident_details)
 
         notifier.send(:notify!, :warning)
       end
@@ -64,15 +64,15 @@ module Backup
 
         incident_details[:details][:status] = :warning
 
-        pagerduty.expects(:get_incident).with(incident_key).returns(incident)
-        incident.expects(:resolve).with("Backup - test label", incident_details)
+        expect(pagerduty).to receive(:get_incident).with(incident_key).and_return(incident)
+        expect(incident).to receive(:resolve).with("Backup - test label", incident_details)
 
         notifier.send(:notify!, :warning)
       end
 
       it "triggers an incident when status is :failure" do
         incident_details[:details][:status] = :failure
-        pagerduty.expects(:trigger).with("Backup - test label", incident_details)
+        expect(pagerduty).to receive(:trigger).with("Backup - test label", incident_details)
 
         notifier.send(:notify!, :failure)
       end

--- a/spec/notifier/prowl_spec.rb
+++ b/spec/notifier/prowl_spec.rb
@@ -58,7 +58,7 @@ module Backup
 
       context "when status is :success" do
         it "sends a success message" do
-          Excon.expects(:post).with(
+          expect(Excon).to receive(:post).with(
             "https://api.prowlapp.com/publicapi/add",
             headers: { "Content-Type" => "application/x-www-form-urlencoded" },
 body: form_data.sub("STATUS", "Success"),
@@ -71,7 +71,7 @@ expects: 200
 
       context "when status is :warning" do
         it "sends a warning message" do
-          Excon.expects(:post).with(
+          expect(Excon).to receive(:post).with(
             "https://api.prowlapp.com/publicapi/add",
             headers: { "Content-Type" => "application/x-www-form-urlencoded" },
 body: form_data.sub("STATUS", "Warning"),
@@ -84,7 +84,7 @@ expects: 200
 
       context "when status is :failure" do
         it "sends a failure message" do
-          Excon.expects(:post).with(
+          expect(Excon).to receive(:post).with(
             "https://api.prowlapp.com/publicapi/add",
             headers: { "Content-Type" => "application/x-www-form-urlencoded" },
 body: form_data.sub("STATUS", "Failure"),

--- a/spec/notifier/pushover_spec.rb
+++ b/spec/notifier/pushover_spec.rb
@@ -66,7 +66,7 @@ module Backup
 
       context "when status is :success" do
         it "sends a success message" do
-          Excon.expects(:post).with(
+          expect(Excon).to receive(:post).with(
             "https://api.pushover.net/1/messages.json",
             headers: { "Content-Type" => "application/x-www-form-urlencoded" },
 body: form_data.sub("STATUS", "Success"),
@@ -79,7 +79,7 @@ expects: 200
 
       context "when status is :warning" do
         it "sends a warning message" do
-          Excon.expects(:post).with(
+          expect(Excon).to receive(:post).with(
             "https://api.pushover.net/1/messages.json",
             headers: { "Content-Type" => "application/x-www-form-urlencoded" },
 body: form_data.sub("STATUS", "Warning"),
@@ -92,7 +92,7 @@ expects: 200
 
       context "when status is :failure" do
         it "sends a failure message" do
-          Excon.expects(:post).with(
+          expect(Excon).to receive(:post).with(
             "https://api.pushover.net/1/messages.json",
             headers: { "Content-Type" => "application/x-www-form-urlencoded" },
 body: form_data.sub("STATUS", "Failure"),
@@ -120,7 +120,7 @@ expects: 200
         end
 
         it "sends message with optional parameters" do
-          Excon.expects(:post).with(
+          expect(Excon).to receive(:post).with(
             "https://api.pushover.net/1/messages.json",
             headers: { "Content-Type" => "application/x-www-form-urlencoded" },
 body: form_data,

--- a/spec/notifier/slack_spec.rb
+++ b/spec/notifier/slack_spec.rb
@@ -89,7 +89,7 @@ module Backup
 
       context "when status is :success" do
         it "sends a success message" do
-          Excon.expects(:post).with do |given_url, options|
+          expect(Excon).to receive(:post) do |given_url, options|
             expected_excon_params(given_url, options, text: "[Backup::Success] test label (test_trigger)")
           end
 
@@ -99,7 +99,7 @@ module Backup
 
       context "when status is :warning" do
         it "sends a warning message" do
-          Excon.expects(:post).with do |given_url, options|
+          expect(Excon).to receive(:post) do |given_url, options|
             expected_excon_params(given_url, options, { text: "[Backup::Warning] test label (test_trigger)" }, true)
           end
 
@@ -109,7 +109,7 @@ module Backup
 
       context "when status is :failure" do
         it "sends a failure message" do
-          Excon.expects(:post).with do |given_url, options|
+          expect(Excon).to receive(:post) do |given_url, options|
             expected_excon_params(given_url, options, { text: "[Backup::Failure] test label (test_trigger)" }, true)
           end
 
@@ -128,7 +128,7 @@ module Backup
         end
 
         it "sends message with optional parameters" do
-          Excon.expects(:post).with do |given_url, options|
+          expect(Excon).to receive(:post) do |given_url, options|
             expected_excon_params(given_url, options, text: "[Backup::Success] test label (test_trigger)",
                                     channel: "my_channel",
                                     username: "my_username",

--- a/spec/notifier/twitter_spec.rb
+++ b/spec/notifier/twitter_spec.rb
@@ -54,21 +54,21 @@ module Backup
 
       context "when status is :success" do
         it "sends a success message" do
-          notifier.expects(:send_message).with(message % "Success")
+          expect(notifier).to receive(:send_message).with(message % "Success")
           notifier.send(:notify!, :success)
         end
       end
 
       context "when status is :warning" do
         it "sends a warning message" do
-          notifier.expects(:send_message).with(message % "Warning")
+          expect(notifier).to receive(:send_message).with(message % "Warning")
           notifier.send(:notify!, :warning)
         end
       end
 
       context "when status is :failure" do
         it "sends a failure message" do
-          notifier.expects(:send_message).with(message % "Failure")
+          expect(notifier).to receive(:send_message).with(message % "Failure")
           notifier.send(:notify!, :failure)
         end
       end
@@ -85,16 +85,16 @@ module Backup
       end
 
       it "sends a message" do
-        client = mock
-        config = mock
+        client = double
+        config = double
 
-        ::Twitter::REST::Client.expects(:new).yields(config).returns(client)
-        config.expects(:consumer_key=).with("my_consumer_key")
-        config.expects(:consumer_secret=).with("my_consumer_secret")
-        config.expects(:access_token=).with("my_oauth_token")
-        config.expects(:access_token_secret=).with("my_oauth_token_secret")
+        expect(::Twitter::REST::Client).to receive(:new).and_yield(config).and_return(client)
+        expect(config).to receive(:consumer_key=).with("my_consumer_key")
+        expect(config).to receive(:consumer_secret=).with("my_consumer_secret")
+        expect(config).to receive(:access_token=).with("my_oauth_token")
+        expect(config).to receive(:access_token_secret=).with("my_oauth_token_secret")
 
-        client.expects(:update).with("a message")
+        expect(client).to receive(:update).with("a message")
 
         notifier.send(:send_message, "a message")
       end

--- a/spec/notifier/zabbix_spec.rb
+++ b/spec/notifier/zabbix_spec.rb
@@ -6,8 +6,8 @@ module Backup
     let(:notifier) { Notifier::Zabbix.new(model) }
 
     before do
-      Utilities.stubs(:utility).with(:zabbix_sender).returns("zabbix_sender")
-      Config.stubs(:hostname).returns("zabbix.hostname")
+      allow(Utilities).to receive(:utility).with(:zabbix_sender).and_return("zabbix_sender")
+      allow(Config).to receive(:hostname).and_return("zabbix.hostname")
     end
 
     it_behaves_like "a class that includes Config::Helpers"
@@ -59,8 +59,8 @@ module Backup
     describe "#notify!" do
       before do
         notifier.service_host = "my.service.host"
-        model.stubs(:duration).returns("12:34:56")
-        notifier.stubs(:zabbix_port).returns(10_051)
+        allow(model).to receive(:duration).and_return("12:34:56")
+        allow(notifier).to receive(:zabbix_port).and_return(10_051)
       end
 
       context "when status is :success" do
@@ -77,10 +77,10 @@ module Backup
           " -o '#{zabbix_msg}'"
         end
 
-        before { model.stubs(:exit_status).returns(0) }
+        before { allow(model).to receive(:exit_status).and_return(0) }
 
         it "sends a Success message" do
-          Utilities.expects(:run).with("echo '#{zabbix_msg}' | #{zabbix_cmd}")
+          expect(Utilities).to receive(:run).with("echo '#{zabbix_msg}' | #{zabbix_cmd}")
           notifier.send(:notify!, :success)
         end
       end
@@ -99,10 +99,10 @@ module Backup
           " -o '#{zabbix_msg}'"
         end
 
-        before { model.stubs(:exit_status).returns(1) }
+        before { allow(model).to receive(:exit_status).and_return(1) }
 
         it "sends a Warning message" do
-          Utilities.expects(:run).with("echo '#{zabbix_msg}' | #{zabbix_cmd}")
+          expect(Utilities).to receive(:run).with("echo '#{zabbix_msg}' | #{zabbix_cmd}")
           notifier.send(:notify!, :warning)
         end
       end
@@ -121,10 +121,10 @@ module Backup
           " -o '#{zabbix_msg}'"
         end
 
-        before { model.stubs(:exit_status).returns(2) }
+        before { allow(model).to receive(:exit_status).and_return(2) }
 
         it "sends a Failure message" do
-          Utilities.expects(:run).with("echo '#{zabbix_msg}' | #{zabbix_cmd}")
+          expect(Utilities).to receive(:run).with("echo '#{zabbix_msg}' | #{zabbix_cmd}")
           notifier.send(:notify!, :failure)
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,10 +32,6 @@ end
 
 RSpec.configure do |config|
   ##
-  # Use Mocha to mock with RSpec
-  config.mock_with :mocha
-
-  ##
   # Example Helpers
   config.include Backup::ExampleHelpers
 
@@ -53,10 +49,10 @@ RSpec.configure do |config|
     SandboxFileUtils.deactivate!(:noop)
 
     # prevent system calls
-    Backup::Utilities.stubs(:gnu_tar?).returns(true)
-    Backup::Utilities.stubs(:utility)
-    Backup::Utilities.stubs(:run)
-    Backup::Pipeline.any_instance.stubs(:run)
+    allow(Backup::Utilities).to receive(:gnu_tar?).and_return(true)
+    allow(Backup::Utilities).to receive(:utility)
+    allow(Backup::Utilities).to receive(:run)
+    allow_any_instance_of(Backup::Pipeline).to receive(:run)
 
     Backup::Utilities.send(:reset!)
     Backup::Config.send(:reset!)

--- a/spec/storage/rsync_spec.rb
+++ b/spec/storage/rsync_spec.rb
@@ -7,10 +7,10 @@ module Backup
     let(:s) { sequence "" }
 
     before do
-      Storage::RSync.any_instance
-        .stubs(:utility).with(:rsync).returns("rsync")
-      Storage::RSync.any_instance
-        .stubs(:utility).with(:ssh).returns("ssh")
+      allow_any_instance_of(Storage::RSync).to \
+        receive(:utility).with(:rsync).and_return("rsync")
+      allow_any_instance_of(Storage::RSync).to \
+        receive(:utility).with(:ssh).and_return("ssh")
     end
 
     it_behaves_like "a class that includes Config::Helpers"
@@ -90,7 +90,7 @@ module Backup
       end
 
       before do
-        storage.package.stubs(:filenames).returns(
+        allow(storage.package).to receive(:filenames).and_return(
           ["test_trigger.tar-aa", "test_trigger.tar-ab"]
         )
       end
@@ -98,26 +98,26 @@ module Backup
       context "local transfer" do
         it "performs transfer with default values" do
           # write_password_file does nothing
-          Tempfile.expects(:new).never
+          expect(Tempfile).to receive(:new).never
 
           # create_remote_path
-          FileUtils.expects(:mkdir_p).with(File.expand_path("~/backups"))
+          expect(FileUtils).to receive(:mkdir_p).with(File.expand_path("~/backups"))
 
           # First Package File
           dest = File.join(File.expand_path("~/backups"), "test_trigger.tar-aa")
-          Logger.expects(:info).in_sequence(s).with(
+          expect(Logger).to receive(:info).ordered.with(
             "Syncing to '#{dest}'..."
           )
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive '#{package_files[0]}' '#{dest}'"
           )
 
           # Second Package File
           dest = File.join(File.expand_path("~/backups"), "test_trigger.tar-ab")
-          Logger.expects(:info).in_sequence(s).with(
+          expect(Logger).to receive(:info).ordered.with(
             "Syncing to '#{dest}'..."
           )
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive '#{package_files[1]}' '#{dest}'"
           )
 
@@ -131,26 +131,26 @@ module Backup
           end
 
           # write_password_file does nothing
-          Tempfile.expects(:new).never
+          expect(Tempfile).to receive(:new).never
 
           # create_remote_path
-          FileUtils.expects(:mkdir_p).with("/my/backups")
+          expect(FileUtils).to receive(:mkdir_p).with("/my/backups")
 
           # First Package File
           dest = "/my/backups/test_trigger.tar-aa"
-          Logger.expects(:info).in_sequence(s).with(
+          expect(Logger).to receive(:info).ordered.with(
             "Syncing to '#{dest}'..."
           )
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive --arg1 --arg2 '#{package_files[0]}' '#{dest}'"
           )
 
           # Second Package File
           dest = "/my/backups/test_trigger.tar-ab"
-          Logger.expects(:info).in_sequence(s).with(
+          expect(Logger).to receive(:info).ordered.with(
             "Syncing to '#{dest}'..."
           )
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive --arg1 --arg2 '#{package_files[1]}' '#{dest}'"
           )
 
@@ -165,22 +165,22 @@ module Backup
           end
 
           # write_password_file does nothing
-          Tempfile.expects(:new).never
+          expect(Tempfile).to receive(:new).never
 
           # create_remote_path
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             %(ssh -p 22 host.name "mkdir -p 'backups'")
           )
 
           # First Package File
           dest = "host.name:'backups/test_trigger.tar-aa'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             %(rsync --archive -e "ssh -p 22" '#{package_files[0]}' #{dest})
           )
 
           # Second Package File
           dest = "host.name:'backups/test_trigger.tar-ab'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             %(rsync --archive -e "ssh -p 22" '#{package_files[1]}' #{dest})
           )
 
@@ -198,17 +198,17 @@ module Backup
           end
 
           # write_password_file does nothing
-          Tempfile.expects(:new).never
+          expect(Tempfile).to receive(:new).never
 
           # create_remote_path
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "ssh -p 123 -l ssh_username -i '/my/id_rsa' " +
             %(host.name "mkdir -p 'backups'")
           )
 
           # First Package File
           dest = "host.name:'backups/test_trigger.tar-aa'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive --opt1 --compress " +
             %(-e "ssh -p 123 -l ssh_username -i '/my/id_rsa'" ) +
             "'#{package_files[0]}' #{dest}"
@@ -216,7 +216,7 @@ module Backup
 
           # Second Package File
           dest = "host.name:'backups/test_trigger.tar-ab'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive --opt1 --compress " +
             %(-e "ssh -p 123 -l ssh_username -i '/my/id_rsa'" ) +
             "'#{package_files[1]}' #{dest}"
@@ -235,21 +235,21 @@ module Backup
           end
 
           # write_password_file does nothing
-          Tempfile.expects(:new).never
+          expect(Tempfile).to receive(:new).never
 
           # create_remote_path does nothing
           # (a call to #run would be an unexpected expectation)
-          FileUtils.expects(:mkdir_p).never
+          expect(FileUtils).to receive(:mkdir_p).never
 
           # First Package File
           dest = "host.name::'module/path/test_trigger.tar-aa'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             %(rsync --archive -e "ssh -p 22" '#{package_files[0]}' #{dest})
           )
 
           # Second Package File
           dest = "host.name::'module/path/test_trigger.tar-ab'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             %(rsync --archive -e "ssh -p 22" '#{package_files[1]}' #{dest})
           )
 
@@ -270,17 +270,17 @@ module Backup
           end
 
           # write_password_file
-          password_file = stub(path: "/path/to/password_file")
-          Tempfile.expects(:new).in_sequence(s)
-            .with("backup-rsync-password").returns(password_file)
-          password_file.expects(:write).in_sequence(s).with("secret")
-          password_file.expects(:close).in_sequence(s)
+          password_file = double(File, path: "/path/to/password_file")
+          expect(Tempfile).to receive(:new).ordered
+            .with("backup-rsync-password").and_return(password_file)
+          expect(password_file).to receive(:write).ordered.with("secret")
+          expect(password_file).to receive(:close).ordered
 
           # create_remote_path does nothing
 
           # First Package File
           dest = "rsync_username@host.name::'backups/test_trigger.tar-aa'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive --opt1 --compress " \
             "--password-file='/path/to/password_file' " +
             %(-e "ssh -p 123 -l ssh_username -i '/my/id_rsa'" ) +
@@ -289,7 +289,7 @@ module Backup
 
           # Second Package File
           dest = "rsync_username@host.name::'backups/test_trigger.tar-ab'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive --opt1 --compress " \
             "--password-file='/path/to/password_file' " +
             %(-e "ssh -p 123 -l ssh_username -i '/my/id_rsa'" ) +
@@ -297,7 +297,7 @@ module Backup
           )
 
           # remove_password_file
-          password_file.expects(:delete).in_sequence(s)
+          expect(password_file).to receive(:delete).ordered
 
           storage.send(:transfer!)
         end
@@ -310,25 +310,25 @@ module Backup
           end
 
           # write_password_file
-          password_file = stub(path: "/path/to/password_file")
-          Tempfile.expects(:new).in_sequence(s)
-            .with("backup-rsync-password").returns(password_file)
-          password_file.expects(:write).in_sequence(s).with("secret")
-          password_file.expects(:close).in_sequence(s)
+          password_file = double(File, path: "/path/to/password_file")
+          expect(Tempfile).to receive(:new).ordered
+            .with("backup-rsync-password").and_return(password_file)
+          expect(password_file).to receive(:write).ordered.with("secret")
+          expect(password_file).to receive(:close).ordered
 
           # create_remote_path does nothing
 
           # First Package File (fails)
           dest = "host.name::'backups/test_trigger.tar-aa'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive " \
             "--password-file='/path/to/password_file' " +
             %(-e "ssh -p 22" ) +
             "'#{package_files[0]}' #{dest}"
-          ).raises("an error")
+          ).and_raise("an error")
 
           # remove_password_file
-          password_file.expects(:delete).in_sequence(s)
+          expect(password_file).to receive(:delete).ordered
 
           expect do
             storage.send(:transfer!)
@@ -349,13 +349,13 @@ module Backup
           end
 
           # write_password_file does nothing
-          Tempfile.expects(:new).never
+          expect(Tempfile).to receive(:new).never
 
           # create_remote_path does nothing
 
           # First Package File
           dest = "rsync_username@host.name::'backups/test_trigger.tar-aa'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive --opt1 --compress " \
             "--password-file='#{File.expand_path("my/pwd_file")}' " +
             %(-e "ssh -p 123 -l ssh_username -i '/my/id_rsa'" ) +
@@ -364,7 +364,7 @@ module Backup
 
           # Second Package File
           dest = "rsync_username@host.name::'backups/test_trigger.tar-ab'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive --opt1 --compress " \
             "--password-file='#{File.expand_path("my/pwd_file")}' " +
             %(-e "ssh -p 123 -l ssh_username -i '/my/id_rsa'" ) +
@@ -384,19 +384,19 @@ module Backup
           end
 
           # write_password_file does nothing
-          Tempfile.expects(:new).never
+          expect(Tempfile).to receive(:new).never
 
           # create_remote_path does nothing
 
           # First Package File
           dest = "host.name::'module/path/test_trigger.tar-aa'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive --port 873 '#{package_files[0]}' #{dest}"
           )
 
           # Second Package File
           dest = "host.name::'module/path/test_trigger.tar-ab'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive --port 873 '#{package_files[1]}' #{dest}"
           )
 
@@ -415,17 +415,17 @@ module Backup
           end
 
           # write_password_file
-          password_file = stub(path: "/path/to/password_file")
-          Tempfile.expects(:new).in_sequence(s)
-            .with("backup-rsync-password").returns(password_file)
-          password_file.expects(:write).in_sequence(s).with("secret")
-          password_file.expects(:close).in_sequence(s)
+          password_file = double(File, path: "/path/to/password_file")
+          expect(Tempfile).to receive(:new).ordered
+            .with("backup-rsync-password").and_return(password_file)
+          expect(password_file).to receive(:write).ordered.with("secret")
+          expect(password_file).to receive(:close).ordered
 
           # create_remote_path does nothing
 
           # First Package File
           dest = "rsync_username@host.name::'backups/test_trigger.tar-aa'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive --opt1 --compress " \
             "--password-file='/path/to/password_file' --port 123 " \
             "'#{package_files[0]}' #{dest}"
@@ -433,14 +433,14 @@ module Backup
 
           # Second Package File
           dest = "rsync_username@host.name::'backups/test_trigger.tar-ab'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive --opt1 --compress " \
             "--password-file='/path/to/password_file' --port 123 " \
             "'#{package_files[1]}' #{dest}"
           )
 
           # remove_password_file!
-          password_file.expects(:delete).in_sequence(s)
+          expect(password_file).to receive(:delete).ordered
 
           storage.send(:transfer!)
         end
@@ -453,24 +453,24 @@ module Backup
           end
 
           # write_password_file
-          password_file = stub(path: "/path/to/password_file")
-          Tempfile.expects(:new).in_sequence(s)
-            .with("backup-rsync-password").returns(password_file)
-          password_file.expects(:write).in_sequence(s).with("secret")
-          password_file.expects(:close).in_sequence(s)
+          password_file = double(File, path: "/path/to/password_file")
+          expect(Tempfile).to receive(:new).ordered
+            .with("backup-rsync-password").and_return(password_file)
+          expect(password_file).to receive(:write).ordered.with("secret")
+          expect(password_file).to receive(:close).ordered
 
           # create_remote_path does nothing
 
           # First Package File (fails)
           dest = "host.name::'backups/test_trigger.tar-aa'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive " \
             "--password-file='/path/to/password_file' --port 873 " \
             "'#{package_files[0]}' #{dest}"
-          ).raises("an error")
+          ).and_raise("an error")
 
           # remove_password_file
-          password_file.expects(:delete).in_sequence(s)
+          expect(password_file).to receive(:delete).ordered
 
           expect do
             storage.send(:transfer!)
@@ -489,13 +489,13 @@ module Backup
           end
 
           # write_password_file does nothing
-          Tempfile.expects(:new).never
+          expect(Tempfile).to receive(:new).never
 
           # create_remote_path does nothing
 
           # First Package File
           dest = "rsync_username@host.name::'backups/test_trigger.tar-aa'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive --opt1 --compress " \
             "--password-file='#{File.expand_path("my/pwd_file")}' --port 123 " \
             "'#{package_files[0]}' #{dest}"
@@ -503,7 +503,7 @@ module Backup
 
           # Second Package File
           dest = "rsync_username@host.name::'backups/test_trigger.tar-ab'"
-          storage.expects(:run).in_sequence(s).with(
+          expect(storage).to receive(:run).ordered.with(
             "rsync --archive --opt1 --compress " \
             "--password-file='#{File.expand_path("my/pwd_file")}' --port 123 " \
             "'#{package_files[1]}' #{dest}"

--- a/spec/support/shared_examples/database.rb
+++ b/spec/support/shared_examples/database.rb
@@ -23,7 +23,7 @@ shared_examples "a subclass of Database::Base" do
 
   describe "#prepare!" do
     it "creates the dump_path" do
-      FileUtils.expects(:mkdir_p).with(db.dump_path)
+      expect(FileUtils).to receive(:mkdir_p).with(db.dump_path)
       db.send(:prepare!)
     end
   end
@@ -32,11 +32,11 @@ shared_examples "a subclass of Database::Base" do
     let(:klass_name) { described_class.name.split("::").last }
 
     before do
-      described_class.any_instance.stubs(:sleep)
+      allow_any_instance_of(described_class).to receive(:sleep)
     end
 
     it "logs warning when model is created if database_id is needed" do
-      Backup::Logger.expects(:warn).with do |err|
+      expect(Backup::Logger).to receive(:warn) do |err|
         expect(err)
           .to be_an_instance_of Backup::Database::Error
       end
@@ -63,7 +63,7 @@ shared_examples "a subclass of Database::Base" do
     end
 
     it "does not warn or auto-generate database_id if only one class defined" do
-      Backup::Logger.expects(:warn).never
+      expect(Backup::Logger).to receive(:warn).never
 
       klass = described_class
       block = respond_to?(:required_config) ? required_config : proc {}
@@ -83,18 +83,18 @@ shared_examples "a subclass of Database::Base" do
       block = respond_to?(:required_config) ? required_config : proc {}
       db = described_class.new(model, :my_id, &block)
 
-      Backup::Logger.expects(:info).with("#{klass_name} (my_id) Started...")
+      expect(Backup::Logger).to receive(:info).with("#{klass_name} (my_id) Started...")
       db.send(:log!, :started)
 
-      Backup::Logger.expects(:info).with("#{klass_name} (my_id) Finished!")
+      expect(Backup::Logger).to receive(:info).with("#{klass_name} (my_id) Finished!")
       db.send(:log!, :finished)
     end
 
     specify "without a database_id" do
-      Backup::Logger.expects(:info).with("#{klass_name} Started...")
+      expect(Backup::Logger).to receive(:info).with("#{klass_name} Started...")
       db.send(:log!, :started)
 
-      Backup::Logger.expects(:info).with("#{klass_name} Finished!")
+      expect(Backup::Logger).to receive(:info).with("#{klass_name} Finished!")
       db.send(:log!, :finished)
     end
   end # describe 'log!'

--- a/spec/syncer/cloud/cloud_files_spec.rb
+++ b/spec/syncer/cloud/cloud_files_spec.rb
@@ -110,7 +110,7 @@ module Backup
 
     describe "#cloud_io" do
       it "caches a new CloudIO instance" do
-        CloudIO::CloudFiles.expects(:new).once.with(
+        expect(CloudIO::CloudFiles).to receive(:new).once.with(
           username: "my_username",
           api_key: "my_api_key",
           auth_url: nil,
@@ -122,7 +122,7 @@ module Backup
           segments_container: nil,
           segment_size: 0,
           fog_options: nil
-        ).returns(:cloud_io)
+        ).and_return(:cloud_io)
 
         expect(syncer.send(:cloud_io)).to eq :cloud_io
         expect(syncer.send(:cloud_io)).to eq :cloud_io
@@ -130,24 +130,26 @@ module Backup
     end # describe '#cloud_io'
 
     describe "#get_remote_files" do
-      let(:cloud_io) { mock }
+      let(:cloud_io) { double }
       let(:object_a) do
-        stub(
+        double(
+          CloudIO::CloudFiles::Object,
           name: "my/path/dir_to_sync/some_dir/object_a",
           hash: "12345"
         )
       end
       let(:object_b) do
-        stub(
+        double(
+          CloudIO::CloudFiles::Object,
           name: "my/path/dir_to_sync/another_dir/object_b",
           hash: "67890"
         )
       end
-      before { syncer.stubs(:cloud_io).returns(cloud_io) }
+      before { allow(syncer).to receive(:cloud_io).and_return(cloud_io) }
 
       it "returns a hash of relative paths and checksums for remote objects" do
-        cloud_io.expects(:objects).with("my/path/dir_to_sync")
-          .returns([object_a, object_b])
+        expect(cloud_io).to receive(:objects).with("my/path/dir_to_sync")
+          .and_return([object_a, object_b])
 
         expect(
           syncer.send(:get_remote_files, "my/path/dir_to_sync")
@@ -157,7 +159,7 @@ module Backup
       end
 
       it "returns an empty hash if no remote objects are found" do
-        cloud_io.expects(:objects).returns([])
+        expect(cloud_io).to receive(:objects).and_return([])
         expect(syncer.send(:get_remote_files, "foo")).to eq({})
       end
     end # describe '#get_remote_files'

--- a/spec/syncer/cloud/local_file_spec.rb
+++ b/spec/syncer/cloud/local_file_spec.rb
@@ -7,7 +7,7 @@ module Backup
         @tmpdir = Dir.mktmpdir("backup_spec")
         SandboxFileUtils.activate!(@tmpdir)
         FileUtils.mkdir_p File.join(@tmpdir, "sync_dir/sub_dir")
-        Utilities.unstub(:utility)
+        allow(Utilities).to receive(:utility).and_call_original
       end
 
       after do
@@ -39,7 +39,7 @@ module Backup
             sanitized_bad_file = "sync_dir/bad\xEF\xBF\xBDfile"
             FileUtils.touch bad_file
 
-            Logger.expects(:warn).with(
+            expect(Logger).to receive(:warn).with(
               "\s\s[skipping] #{File.expand_path(sanitized_bad_file)}\n" \
               "\s\sPath Contains Invalid UTF-8 byte sequences"
             )

--- a/spec/syncer/rsync/local_spec.rb
+++ b/spec/syncer/rsync/local_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 module Backup
   describe Syncer::RSync::Local do
     before do
-      Syncer::RSync::Local.any_instance
-        .stubs(:utility).with(:rsync).returns("rsync")
+      allow_any_instance_of(Syncer::RSync::Local).to \
+        receive(:utility).with(:rsync).and_return("rsync")
     end
 
     describe "#initialize" do
@@ -96,9 +96,9 @@ module Backup
           end
         end
 
-        FileUtils.expects(:mkdir_p).with(File.expand_path("~/my_backups/"))
+        expect(FileUtils).to receive(:mkdir_p).with(File.expand_path("~/my_backups/"))
 
-        syncer.expects(:run).with(
+        expect(syncer).to receive(:run).with(
           "rsync --archive --delete --opt-a --opt-b " \
           "'/some/directory' '#{File.expand_path("~/home/directory")}' " \
           "'#{File.expand_path("~/my_backups")}'"
@@ -118,9 +118,9 @@ module Backup
           end
         end
 
-        FileUtils.expects(:mkdir_p).with(File.expand_path("~/my_backups/"))
+        expect(FileUtils).to receive(:mkdir_p).with(File.expand_path("~/my_backups/"))
 
-        syncer.expects(:run).with(
+        expect(syncer).to receive(:run).with(
           "rsync --archive --opt-a --opt-b " \
           "'/some/directory' '#{File.expand_path("~/home/directory")}' " \
           "'#{File.expand_path("~/my_backups")}'"
@@ -141,9 +141,9 @@ module Backup
           end
         end
 
-        FileUtils.expects(:mkdir_p).with(File.expand_path("~/my_backups/"))
+        expect(FileUtils).to receive(:mkdir_p).with(File.expand_path("~/my_backups/"))
 
-        syncer.expects(:run).with(
+        expect(syncer).to receive(:run).with(
           "rsync --opt-a --opt-b " \
           "'/some/directory' '#{File.expand_path("~/home/directory")}' " \
           "'#{File.expand_path("~/my_backups")}'"
@@ -166,9 +166,9 @@ module Backup
           end
         end
 
-        FileUtils.expects(:mkdir_p).with(File.expand_path("~/my_backups/"))
+        expect(FileUtils).to receive(:mkdir_p).with(File.expand_path("~/my_backups/"))
 
-        syncer.expects(:run).with(
+        expect(syncer).to receive(:run).with(
           "rsync --archive --delete --exclude='*~' --exclude='tmp/' " \
           "--opt-a --opt-b " \
           "'/some/directory' '#{File.expand_path("~/home/directory")}' " \
@@ -182,16 +182,16 @@ module Backup
         it "logs started/finished messages" do
           syncer = Syncer::RSync::Local.new
 
-          Logger.expects(:info).with("Syncer::RSync::Local Started...")
-          Logger.expects(:info).with("Syncer::RSync::Local Finished!")
+          expect(Logger).to receive(:info).with("Syncer::RSync::Local Started...")
+          expect(Logger).to receive(:info).with("Syncer::RSync::Local Finished!")
           syncer.perform!
         end
 
         it "logs messages using optional syncer_id" do
           syncer = Syncer::RSync::Local.new("My Syncer")
 
-          Logger.expects(:info).with("Syncer::RSync::Local (My Syncer) Started...")
-          Logger.expects(:info).with("Syncer::RSync::Local (My Syncer) Finished!")
+          expect(Logger).to receive(:info).with("Syncer::RSync::Local (My Syncer) Started...")
+          expect(Logger).to receive(:info).with("Syncer::RSync::Local (My Syncer) Finished!")
           syncer.perform!
         end
       end

--- a/spec/syncer/rsync/pull_spec.rb
+++ b/spec/syncer/rsync/pull_spec.rb
@@ -3,10 +3,10 @@ require "spec_helper"
 module Backup
   describe Syncer::RSync::Pull do
     before do
-      Syncer::RSync::Pull.any_instance
-        .stubs(:utility).with(:rsync).returns("rsync")
-      Syncer::RSync::Pull.any_instance
-        .stubs(:utility).with(:ssh).returns("ssh")
+      allow_any_instance_of(Syncer::RSync::Pull).to \
+        receive(:utility).with(:rsync).and_return("rsync")
+      allow_any_instance_of(Syncer::RSync::Pull).to \
+        receive(:utility).with(:ssh).and_return("ssh")
     end
 
     describe "#perform!" do
@@ -23,9 +23,9 @@ module Backup
             end
           end
 
-          FileUtils.expects(:mkdir_p).with(File.expand_path("~/some/path/"))
+          expect(FileUtils).to receive(:mkdir_p).with(File.expand_path("~/some/path/"))
 
-          syncer.expects(:run).with(
+          expect(syncer).to receive(:run).with(
             "rsync --archive -e \"ssh -p 22\" " \
             "my_host:'/this/dir' :'that/dir' :'home/dir' " \
             "'#{File.expand_path("~/some/path/")}'"
@@ -45,9 +45,9 @@ module Backup
             end
           end
 
-          FileUtils.expects(:mkdir_p).with(File.expand_path("~/some/path/"))
+          expect(FileUtils).to receive(:mkdir_p).with(File.expand_path("~/some/path/"))
 
-          syncer.expects(:run).with(
+          expect(syncer).to receive(:run).with(
             "rsync --archive -e \"ssh -p 22\" " \
             "my_host::'/this/dir' ::'that/dir' ::'home/dir' " \
             "'#{File.expand_path("~/some/path/")}'"
@@ -67,9 +67,9 @@ module Backup
             end
           end
 
-          FileUtils.expects(:mkdir_p).with(File.expand_path("~/some/path/"))
+          expect(FileUtils).to receive(:mkdir_p).with(File.expand_path("~/some/path/"))
 
-          syncer.expects(:run).with(
+          expect(syncer).to receive(:run).with(
             "rsync --archive --port 873 " \
             "my_host::'/this/dir' ::'that/dir' ::'home/dir' " \
             "'#{File.expand_path("~/some/path/")}'"
@@ -83,17 +83,17 @@ module Backup
         let(:syncer) { Syncer::RSync::Pull.new }
 
         it "writes and removes the temporary password file" do
-          syncer.expects(:write_password_file!).in_sequence(s)
-          syncer.expects(:run).in_sequence(s)
-          syncer.expects(:remove_password_file!).in_sequence(s)
+          expect(syncer).to receive(:write_password_file!).ordered
+          expect(syncer).to receive(:run).ordered
+          expect(syncer).to receive(:remove_password_file!).ordered
 
           syncer.perform!
         end
 
         it "ensures temporary password file removal" do
-          syncer.expects(:write_password_file!).in_sequence(s)
-          syncer.expects(:run).in_sequence(s).raises(VerySpecificError)
-          syncer.expects(:remove_password_file!).in_sequence(s)
+          expect(syncer).to receive(:write_password_file!).ordered
+          expect(syncer).to receive(:run).ordered.and_raise(VerySpecificError)
+          expect(syncer).to receive(:remove_password_file!).ordered
 
           expect do
             syncer.perform!
@@ -105,16 +105,16 @@ module Backup
         it "logs started/finished messages" do
           syncer = Syncer::RSync::Pull.new
 
-          Logger.expects(:info).with("Syncer::RSync::Pull Started...")
-          Logger.expects(:info).with("Syncer::RSync::Pull Finished!")
+          expect(Logger).to receive(:info).with("Syncer::RSync::Pull Started...")
+          expect(Logger).to receive(:info).with("Syncer::RSync::Pull Finished!")
           syncer.perform!
         end
 
         it "logs messages using optional syncer_id" do
           syncer = Syncer::RSync::Pull.new("My Syncer")
 
-          Logger.expects(:info).with("Syncer::RSync::Pull (My Syncer) Started...")
-          Logger.expects(:info).with("Syncer::RSync::Pull (My Syncer) Finished!")
+          expect(Logger).to receive(:info).with("Syncer::RSync::Pull (My Syncer) Started...")
+          expect(Logger).to receive(:info).with("Syncer::RSync::Pull (My Syncer) Finished!")
           syncer.perform!
         end
       end

--- a/spec/syncer/rsync/push_spec.rb
+++ b/spec/syncer/rsync/push_spec.rb
@@ -3,10 +3,10 @@ require "spec_helper"
 module Backup
   describe Syncer::RSync::Push do
     before do
-      Syncer::RSync::Push.any_instance
-        .stubs(:utility).with(:rsync).returns("rsync")
-      Syncer::RSync::Push.any_instance
-        .stubs(:utility).with(:ssh).returns("ssh")
+      allow_any_instance_of(Syncer::RSync::Push).to \
+        receive(:utility).with(:rsync).and_return("rsync")
+      allow_any_instance_of(Syncer::RSync::Push).to \
+        receive(:utility).with(:ssh).and_return("ssh")
     end
 
     describe "#initialize" do
@@ -179,8 +179,8 @@ module Backup
             end
           end
 
-          syncer.expects(:create_dest_path!)
-          syncer.expects(:run).with(
+          expect(syncer).to receive(:create_dest_path!)
+          expect(syncer).to receive(:run).with(
             "rsync --archive --delete --compress " \
             "-e \"ssh -p 22 -l ssh_username\" " \
             "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -202,8 +202,8 @@ module Backup
             end
           end
 
-          syncer.expects(:create_dest_path!)
-          syncer.expects(:run).with(
+          expect(syncer).to receive(:create_dest_path!)
+          expect(syncer).to receive(:run).with(
             "rsync --archive --compress " \
             "-e \"ssh -p 22 -l ssh_username\" " \
             "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -224,8 +224,8 @@ module Backup
             end
           end
 
-          syncer.expects(:create_dest_path!)
-          syncer.expects(:run).with(
+          expect(syncer).to receive(:create_dest_path!)
+          expect(syncer).to receive(:run).with(
             "rsync --archive --delete " \
             "-e \"ssh -p 22\" " \
             "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -245,8 +245,8 @@ module Backup
             end
           end
 
-          syncer.expects(:create_dest_path!)
-          syncer.expects(:run).with(
+          expect(syncer).to receive(:create_dest_path!)
+          expect(syncer).to receive(:run).with(
             "rsync --archive " \
             "-e \"ssh -p 22\" " \
             "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -270,8 +270,8 @@ module Backup
             end
           end
 
-          syncer.expects(:create_dest_path!)
-          syncer.expects(:run).with(
+          expect(syncer).to receive(:create_dest_path!)
+          expect(syncer).to receive(:run).with(
             "rsync --archive --delete --opt-a --opt-b " \
             "-e \"ssh -p 22\" " \
             "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -292,8 +292,8 @@ module Backup
             end
           end
 
-          syncer.expects(:create_dest_path!)
-          syncer.expects(:run).with(
+          expect(syncer).to receive(:create_dest_path!)
+          expect(syncer).to receive(:run).with(
             "rsync --archive --opt-a --opt-b " \
             "-e \"ssh -p 22\" " \
             "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -316,8 +316,8 @@ module Backup
             end
           end
 
-          syncer.expects(:create_dest_path!)
-          syncer.expects(:run).with(
+          expect(syncer).to receive(:create_dest_path!)
+          expect(syncer).to receive(:run).with(
             "rsync --archive --exclude='*~' --exclude='tmp/' --opt-a --opt-b " \
             "-e \"ssh -p 22\" " \
             "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -329,7 +329,7 @@ module Backup
 
       describe "rsync password options" do
         let(:s) { sequence "" }
-        let(:password_file) { mock }
+        let(:password_file) { double }
 
         context "when an rsync_password is given" do
           let(:syncer) do
@@ -349,15 +349,15 @@ module Backup
           end
 
           before do
-            password_file.stubs(:path).returns("path/to/password_file")
-            Tempfile.expects(:new).in_sequence(s)
-              .with("backup-rsync-password").returns(password_file)
-            password_file.expects(:write).in_sequence(s).with("my_password")
-            password_file.expects(:close).in_sequence(s)
+            allow(password_file).to receive(:path).and_return("path/to/password_file")
+            expect(Tempfile).to receive(:new).ordered
+              .with("backup-rsync-password").and_return(password_file)
+            expect(password_file).to receive(:write).ordered.with("my_password")
+            expect(password_file).to receive(:close).ordered
           end
 
           it "creates and uses a temp file for the password" do
-            syncer.expects(:run).in_sequence(s).with(
+            expect(syncer).to receive(:run).ordered.with(
               "rsync --archive --delete --compress " \
               "--password-file='#{File.expand_path("path/to/password_file")}' " \
               "--port 873 " \
@@ -365,15 +365,15 @@ module Backup
               "rsync_username@my_host::'my_module'"
             )
 
-            password_file.expects(:delete).in_sequence(s)
+            expect(password_file).to receive(:delete).ordered
 
             syncer.perform!
           end
 
           it "ensures tempfile removal" do
-            syncer.expects(:run).in_sequence(s).raises("error message")
+            expect(syncer).to receive(:run).ordered.and_raise("error message")
 
-            password_file.expects(:delete).in_sequence(s)
+            expect(password_file).to receive(:delete).ordered
 
             expect do
               syncer.perform!
@@ -400,11 +400,11 @@ module Backup
           end
 
           before do
-            Tempfile.expects(:new).never
+            expect(Tempfile).to receive(:new).never
           end
 
           it "uses the given path" do
-            syncer.expects(:run).in_sequence(s).with(
+            expect(syncer).to receive(:run).ordered.with(
               "rsync --archive --delete --compress " \
               "--password-file='#{File.expand_path("path/to/my_password")}' " \
               "-e \"ssh -p 22 -l ssh_username\" " \
@@ -435,12 +435,12 @@ module Backup
           end
 
           before do
-            Tempfile.expects(:new).never
+            expect(Tempfile).to receive(:new).never
           end
 
           it "uses no rsync_user, tempfile or password_option" do
-            syncer.expects(:create_dest_path!)
-            syncer.expects(:run).in_sequence(s).with(
+            expect(syncer).to receive(:create_dest_path!)
+            expect(syncer).to receive(:run).ordered.with(
               "rsync --archive --delete --compress " \
               "-e \"ssh -p 22 -l ssh_username\" " \
               "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -467,7 +467,7 @@ module Backup
               end
             end
 
-            syncer.expects(:run).with(
+            expect(syncer).to receive(:run).with(
               "rsync --archive --delete --opt-a --opt-b --compress " \
               "--port 873 " \
               "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -491,7 +491,7 @@ module Backup
               end
             end
 
-            syncer.expects(:run).with(
+            expect(syncer).to receive(:run).with(
               "rsync --archive --delete --opt-a --opt-b " \
               "--port 789 " \
               "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -518,7 +518,7 @@ module Backup
               end
             end
 
-            syncer.expects(:run).with(
+            expect(syncer).to receive(:run).with(
               "rsync --archive --delete --opt-a --opt-b --compress " \
               "-e \"ssh -p 22 --opt1 --opt2\" " \
               "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -544,7 +544,7 @@ module Backup
               end
             end
 
-            syncer.expects(:run).with(
+            expect(syncer).to receive(:run).with(
               "rsync --archive --delete --opt-a --opt-b --compress " \
               "-e \"ssh -p 789 -l ssh_username -i '/my/identity_file'\" " \
               "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -572,8 +572,8 @@ module Backup
               end
             end
 
-            syncer.expects(:create_dest_path!)
-            syncer.expects(:run).with(
+            expect(syncer).to receive(:create_dest_path!)
+            expect(syncer).to receive(:run).with(
               "rsync --archive --delete --opt-a 'something' --compress " \
               "-e \"ssh -p 22 -l ssh_username --opt1 --opt2\" " \
               "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -599,12 +599,12 @@ module Backup
               end
             end
 
-            syncer.expects(:run).with(
+            expect(syncer).to receive(:run).with(
               "ssh -p 22 -l ssh_username -i '/path/to/id_rsa' my_host " +
               %("mkdir -p 'some/path'")
             )
 
-            syncer.expects(:run).with(
+            expect(syncer).to receive(:run).with(
               "rsync --archive " \
               "-e \"ssh -p 22 -l ssh_username -i '/path/to/id_rsa'\" " \
               "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -627,7 +627,7 @@ module Backup
               end
             end
 
-            syncer.expects(:run).with(
+            expect(syncer).to receive(:run).with(
               "rsync --archive " \
               "-e \"ssh -p 22 -l ssh_username -i '/path/to/id_rsa'\" " \
               "'/this/dir' '#{File.expand_path("that/dir")}' " \
@@ -643,16 +643,16 @@ module Backup
         it "logs started/finished messages" do
           syncer = Syncer::RSync::Push.new
 
-          Logger.expects(:info).with("Syncer::RSync::Push Started...")
-          Logger.expects(:info).with("Syncer::RSync::Push Finished!")
+          expect(Logger).to receive(:info).with("Syncer::RSync::Push Started...")
+          expect(Logger).to receive(:info).with("Syncer::RSync::Push Finished!")
           syncer.perform!
         end
 
         it "logs messages using optional syncer_id" do
           syncer = Syncer::RSync::Push.new("My Syncer")
 
-          Logger.expects(:info).with("Syncer::RSync::Push (My Syncer) Started...")
-          Logger.expects(:info).with("Syncer::RSync::Push (My Syncer) Finished!")
+          expect(Logger).to receive(:info).with("Syncer::RSync::Push (My Syncer) Started...")
+          expect(Logger).to receive(:info).with("Syncer::RSync::Push (My Syncer) Finished!")
           syncer.perform!
         end
       end


### PR DESCRIPTION
Drop Mocha stub library to use the built-in RSpec mocks instead.

Closes #823 