### PR TITLE
OpenSSL options fix (added some keys to remove warning about deprecat…

### DIFF
--- a/lib/backup/encryptor/open_ssl.rb
+++ b/lib/backup/encryptor/open_ssl.rb
@@ -56,7 +56,7 @@ module Backup
       # Always sets a password option, if even no password is given,
       # but will prefer the password_file option if both are given.
       def options
-        opts = ["aes-256-cbc"]
+        opts = ["aes-256-cbc -md sha512 -pbkdf2 -iter 1000"]
         opts << "-base64" if @base64
         opts << "-salt"   if @salt
 


### PR DESCRIPTION
Hi, this commit fix the problem with "*** WARNING : deprecated key derivation used" Using -iter or -pbkdf2 would be better."
The discussion is here:
https://askubuntu.com/questions/1093591/how-should-i-change-encryption-according-to-warning-deprecated-key-derivat