### PR TITLE
Make command exit with status 1 on failure

### DIFF
--- a/lib/backup/cli.rb
+++ b/lib/backup/cli.rb
@@ -345,6 +345,13 @@ module Backup
       puts "Backup #{Backup::VERSION}"
     end
 
+    class << self
+      # If this returns `true`, it exits with status 1 on failure for CLI options and arguments errors.
+      def exit_on_failure?
+        true
+      end
+    end
+
     # This is to avoid Thor's warnings when stubbing methods on the Thor class.
     module Helpers
       class << self


### PR DESCRIPTION
I think command line tools should exit with status `1` or larger when it fails. But `backup` command doesn't. By this patch, it exits with status `1` on failure.