### PR TITLE
Don't depend on needless gems

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "thor", "~> 0.18", ">= 0.18.1"
   gem.add_dependency "open4", "1.3.0"
-  gem.add_dependency "fog", "~> 1.42"
+  gem.add_dependency "fog-aws", ">= 0.6.0"
+  gem.add_dependency "fog-rackspace", ">= 0"
   gem.add_dependency "excon", "~> 0.71"
   gem.add_dependency "unf", "0.1.3" # for fog/AWS
   gem.add_dependency "dropbox-sdk", "1.6.5"

--- a/backup.gemspec
+++ b/backup.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "thor", "~> 0.18", ">= 0.18.1"
   gem.add_dependency "open4", "1.3.0"
-  gem.add_dependency "fog-aws", ">= 0.6.0"
-  gem.add_dependency "fog-rackspace", ">= 0"
+  gem.add_dependency "fog-aws", "~> 3.12"
+  gem.add_dependency "fog-rackspace", "~> 0.1.6"
   gem.add_dependency "excon", "~> 0.71"
   gem.add_dependency "unf", "0.1.3" # for fog/AWS
   gem.add_dependency "dropbox-sdk", "1.6.5"

--- a/lib/backup/cloud_io/cloud_files.rb
+++ b/lib/backup/cloud_io/cloud_files.rb
@@ -1,5 +1,5 @@
 require "backup/cloud_io/base"
-require "fog"
+require "fog/rackspace"
 require "digest/md5"
 
 module Backup

--- a/lib/backup/cloud_io/s3.rb
+++ b/lib/backup/cloud_io/s3.rb
@@ -1,5 +1,5 @@
 require "backup/cloud_io/base"
-require "fog"
+require "fog/aws"
 require "digest/md5"
 require "base64"
 require "stringio"


### PR DESCRIPTION
Now fog gem dependent on, via fog-ovirt gem, ovirt library. I think it's not good that a sysadmin tool depends on needless package, isn't it?