### PR TITLE
Fix yaml loading

### DIFF
--- a/lib/backup/storage/cycler.rb
+++ b/lib/backup/storage/cycler.rb
@@ -53,7 +53,11 @@ module Backup
       def yaml_load
         loaded =
           if File.exist?(yaml_file) && !File.zero?(yaml_file)
-            YAML.load_file(yaml_file)
+            if YAML.name == 'Psych' && Psych::VERSION >= '3.1'
+              YAML.safe_load_file(yaml_file, permitted_classes: [Backup::Package])
+            else
+              YAML.load_file(yaml_file)
+            end
           else
             []
           end

--- a/lib/backup/storage/cycler.rb
+++ b/lib/backup/storage/cycler.rb
@@ -51,11 +51,14 @@ module Backup
 
       # Returns stored Package objects, sorted by #time descending (oldest last).
       def yaml_load
-        if File.exist?(yaml_file) && !File.zero?(yaml_file)
-          YAML.load_file(yaml_file).sort_by!(&:time).reverse!
-        else
-          []
-        end
+        loaded =
+          if File.exist?(yaml_file) && !File.zero?(yaml_file)
+            YAML.load_file(yaml_file)
+          else
+            []
+          end
+
+        loaded.sort_by!(&:time).reverse!
       end
 
       # Stores the given package objects to the YAML data file.


### PR DESCRIPTION
YAML loading in this place is broken since (presumably) Ruby 3.1 because Psych by default refuses to deserialize into non plain data structures for security reasons.

This fix is along the lines of https://github.com/sparklemotion/http-cookie/pull/34/files.

It looks like all properties of `Backup::Package` store plain values, so permitting deserialization into `Backup::Package` should be sufficient.

Fixes https://github.com/backup/backup/issues/978