### PR TITLE
Ruby 3.1 compatibility

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         # ruby: ['2.5', '2.7', '3.0', '3.1', truffleruby]
-        ruby: ['2.5', '2.6', '2.7']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
     env:
       BUNDLE_WITHOUT: no_ci
     steps:

--- a/backup.gemspec
+++ b/backup.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.require_path  = "lib"
   gem.executables   = ["backup"]
 
-  gem.required_ruby_version = ">= 2.0"
+  gem.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
   gem.add_dependency "thor", "~> 0.18", ">= 0.18.1"
   gem.add_dependency "open4", "1.3.0"
@@ -36,6 +36,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-ssh", "5.2.0"
   gem.add_dependency "net-scp", "~> 2.0.0"
   gem.add_dependency "net-sftp", "2.1.2"
+  gem.add_dependency "net-ftp", "~> 0.1.3"
+  gem.add_dependency "net-smtp", "~> 0.1.0"
   gem.add_dependency "mail", "~> 2.6", ">= 2.6.6"
   gem.add_dependency "pagerduty", "2.0.0"
   gem.add_dependency "twitter", "~> 6.0"
@@ -49,5 +51,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "0.48.1"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "3.8.0"
-  gem.add_development_dependency "timecop", "0.9.1"
+  gem.add_development_dependency "timecop", "0.9.4"
 end

--- a/lib/backup/template.rb
+++ b/lib/backup/template.rb
@@ -26,7 +26,11 @@ module Backup
     ##
     # Returns a String object containing the contents of the file (in the context of the binding if any)
     def result(file)
-      ERB.new(file_contents(file), nil, "<>").result(binding)
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0.0")
+        ERB.new(file_contents(file), trim_mode: "<>")
+      else
+        ERB.new(file_contents(file), nil, "<>")
+      end.result(binding)
     end
 
     private

--- a/spec/support/sandbox_file_utils.rb
+++ b/spec/support/sandbox_file_utils.rb
@@ -190,7 +190,7 @@ module SandboxFileUtils
       rm_rf rmtree touch
     ].each do |name|
       class_eval(<<-EOS, __FILE__, __LINE__ + 1)
-        def #{name}(list, options = {})
+        def #{name}(list, **options)
           protect!(list)
           super
         end
@@ -199,7 +199,7 @@ module SandboxFileUtils
 
     %w[cp copy cp_r install].each do |name|
       class_eval(<<-EOS, __FILE__, __LINE__ + 1)
-        def #{name}(src, dest, options = {})
+        def #{name}(src, dest, **options)
           protect!(dest)
           super
         end
@@ -208,7 +208,7 @@ module SandboxFileUtils
 
     %w[ln link ln_s symlink ln_sf mv move].each do |name|
       class_eval(<<-EOS, __FILE__, __LINE__ + 1)
-        def #{name}(src, dest, options = {})
+        def #{name}(src, dest, **options)
           protect!(src)
           super
         end
@@ -217,7 +217,7 @@ module SandboxFileUtils
 
     %w[chmod chmod_R].each do |name|
       class_eval(<<-EOS, __FILE__, __LINE__ + 1)
-        def #{name}(mode, list, options = {})
+        def #{name}(mode, list, **options)
           protect!(list)
           super
         end
@@ -226,7 +226,7 @@ module SandboxFileUtils
 
     %w[chown chown_R].each do |name|
       class_eval(<<-EOS, __FILE__, __LINE__ + 1)
-        def #{name}(user, group, list, options = {})
+        def #{name}(user, group, list, **options)
           protect!(list)
           super
         end

--- a/spec/support/shared_examples/storage.rb
+++ b/spec/support/shared_examples/storage.rb
@@ -67,7 +67,14 @@ shared_examples "a storage that cycles" do
       end
       expect(File).to receive(:exist?).with(yaml_file).and_return(true)
       expect(File).to receive(:zero?).with(yaml_file).and_return(false)
-      expect(YAML).to receive(:load_file).with(yaml_file).and_return(stored_packages)
+
+      if YAML.respond_to? :safe_load_file
+        expect(YAML).to receive(:safe_load_file)
+          .with(yaml_file, permitted_classes: [Backup::Package])
+      else
+        expect(YAML).to receive(:load_file).with(yaml_file)
+      end.and_return(stored_packages)
+
       allow(storage).to receive(:transfer!)
     end
 


### PR DESCRIPTION
This PR is a first pass at working on ruby 3.1 compat for backup.

* BREAKING CHANGE*: Support is dropped for rubies < 2.3 (TBH, I'm considering dropping support for ruby < 2.5, which is current debian oldstable)
* Various minor fixes