### PR TITLE
Openssl pbkdf2

### DIFF
--- a/lib/backup/encryptor/open_ssl.rb
+++ b/lib/backup/encryptor/open_ssl.rb
@@ -1,6 +1,12 @@
 module Backup
   module Encryptor
     class OpenSSL < Base
+      BASE_OPTIONS = [
+        "aes-256-cbc",
+        "-pbkdf2",
+        "-iter", "310000" # As per OWASP "Password Storage Cheat Sheet"
+      ].freeze
+
       ##
       # The password that'll be used to encrypt the backup. This
       # password will be required to decrypt the backup later on.
@@ -56,7 +62,7 @@ module Backup
       # Always sets a password option, if even no password is given,
       # but will prefer the password_file option if both are given.
       def options
-        opts = ["aes-256-cbc"]
+        opts = BASE_OPTIONS.dup
         opts << "-base64" if @base64
         opts << "-salt"   if @salt
 

--- a/lib/backup/encryptor/open_ssl.rb
+++ b/lib/backup/encryptor/open_ssl.rb
@@ -22,6 +22,7 @@ module Backup
 
       ##
       # Determines whether the 'salt' flag should be used
+      # *DEPRECATED*: This is the default behavior, this flag is useless
       attr_accessor :salt
 
       ##
@@ -57,14 +58,11 @@ module Backup
       # The -base64 option will make the encrypted output base64 encoded,
       # this makes the encrypted file readable using text editors
       #
-      # The -salt option adds strength to the encryption
-      #
       # Always sets a password option, if even no password is given,
       # but will prefer the password_file option if both are given.
       def options
         opts = BASE_OPTIONS.dup
         opts << "-base64" if @base64
-        opts << "-salt"   if @salt
 
         opts <<
           if @password_file.to_s.empty?

--- a/spec/encryptor/open_ssl_spec.rb
+++ b/spec/encryptor/open_ssl_spec.rb
@@ -6,7 +6,6 @@ describe Backup::Encryptor::OpenSSL do
       e.password      = "mypassword"
       e.password_file = "/my/password/file"
       e.base64        = true
-      e.salt          = true
     end
   end
 
@@ -28,7 +27,6 @@ describe Backup::Encryptor::OpenSSL do
         expect(encryptor.password).to       eq("mypassword")
         expect(encryptor.password_file).to  eq("/my/password/file")
         expect(encryptor.base64).to         eq(true)
-        expect(encryptor.salt).to           eq(true)
       end
 
       it "should use default values if none are given" do
@@ -36,7 +34,6 @@ describe Backup::Encryptor::OpenSSL do
         expect(encryptor.password).to       be_nil
         expect(encryptor.password_file).to  be_nil
         expect(encryptor.base64).to         eq(false)
-        expect(encryptor.salt).to           eq(true)
       end
     end # context 'when no pre-configured defaults have been set'
 
@@ -46,7 +43,6 @@ describe Backup::Encryptor::OpenSSL do
           e.password      = "default_password"
           e.password_file = "/default/password/file"
           e.base64        = "default_base64"
-          e.salt          = "default_salt"
         end
       end
 
@@ -55,14 +51,12 @@ describe Backup::Encryptor::OpenSSL do
         encryptor.password      = "default_password"
         encryptor.password_file = "/default/password/file"
         encryptor.base64        = "default_base64"
-        encryptor.salt          = "default_salt"
       end
 
       it "should override pre-configured defaults" do
         expect(encryptor.password).to       eq("mypassword")
         expect(encryptor.password_file).to  eq("/my/password/file")
         expect(encryptor.base64).to         eq(true)
-        expect(encryptor.salt).to           eq(true)
       end
     end # context 'when pre-configured defaults have been set'
   end # describe '#initialize'
@@ -82,11 +76,6 @@ describe Backup::Encryptor::OpenSSL do
 
   describe "#options" do
     let(:encryptor) { Backup::Encryptor::OpenSSL.new }
-
-    before do
-      # salt is true by default
-      encryptor.salt = false
-    end
 
     context "with no options given" do
       it "should always include cipher command" do

--- a/spec/encryptor/open_ssl_spec.rb
+++ b/spec/encryptor/open_ssl_spec.rb
@@ -95,7 +95,7 @@ describe Backup::Encryptor::OpenSSL do
 
       it "should add #password option whenever #password_file not given" do
         expect(encryptor.send(:options)).to eq(
-          "aes-256-cbc -k ''"
+          "aes-256-cbc -pbkdf2 -iter 310000 -k ''"
         )
       end
     end
@@ -105,14 +105,14 @@ describe Backup::Encryptor::OpenSSL do
 
       it "should add #password_file option" do
         expect(encryptor.send(:options)).to eq(
-          "aes-256-cbc -pass file:password_file"
+          "aes-256-cbc -pbkdf2 -iter 310000 -pass file:password_file"
         )
       end
 
       it "should add #password_file option even when #password given" do
         encryptor.password = "password"
         expect(encryptor.send(:options)).to eq(
-          "aes-256-cbc -pass file:password_file"
+          "aes-256-cbc -pbkdf2 -iter 310000 -pass file:password_file"
         )
       end
     end
@@ -122,7 +122,7 @@ describe Backup::Encryptor::OpenSSL do
 
       it "should include the given password in the #password option" do
         expect(encryptor.send(:options)).to eq(
-          %q(aes-256-cbc -k pa\\\ss\'w\"ord)
+          %q(aes-256-cbc -pbkdf2 -iter 310000 -k pa\\\ss\'w\"ord)
         )
       end
     end
@@ -132,17 +132,7 @@ describe Backup::Encryptor::OpenSSL do
 
       it "should add the option" do
         expect(encryptor.send(:options)).to eq(
-          "aes-256-cbc -base64 -k ''"
-        )
-      end
-    end
-
-    context "when #salt is true" do
-      before { encryptor.salt = true }
-
-      it "should add the option" do
-        expect(encryptor.send(:options)).to eq(
-          "aes-256-cbc -salt -k ''"
+          "aes-256-cbc -pbkdf2 -iter 310000 -base64 -k ''"
         )
       end
     end


### PR DESCRIPTION
Use public key derivation function 2 with OWASP recommended iterations  (cf #949)

Also deprecate the `salt` attribute with is the default anyway (see `man enc`)