### PR TITLE
Relax "net-smtp" dependency (to fix `$SAFE > 0`)

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "net-scp", "~> 2.0.0"
   gem.add_dependency "net-sftp", "2.1.2"
   gem.add_dependency "net-ftp", "~> 0.1.3"
-  gem.add_dependency "net-smtp", "~> 0.1.0"
+  gem.add_dependency "net-smtp", "~> 0.1"
   gem.add_dependency "mail", "~> 2.6", ">= 2.6.6"
   gem.add_dependency "pagerduty", "2.0.0"
   gem.add_dependency "twitter", "~> 6.0"


### PR DESCRIPTION
[A couple months ago](https://github.com/backup/backup/commit/49bf0fd47b7955f3e1d9cd83014c57389aeab37c) `net-smtp ~>1.0.1` was added as an explicit dependency to this gem.

However, this version still uses the `$SAFE` global variable that was since then removed from Ruby 3.0 (https://bugs.ruby-lang.org/issues/16131), so when I sent a notification email after a backup, I got this error: 

```
NoMethodError: undefined method `>' for nil:NilClass

if $SAFE > 0
  ^^^^^^^^^^
```

Relaxing the dependency fixed this issue because the code using `$SAFE` was removed from `net-smtp 0.2.0`: https://github.com/ruby/net-smtp/commit/8fbd08af6cebbb111d2172090531fa60fa6275f3