### PR TITLE
Update ssh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ruby:2.4.3
+FROM ruby:3.1.3
+
 
 ## 1. Image metadata ##
  LABEL maintainer="stuart@stuartellis.name" \
@@ -10,8 +11,8 @@ FROM ruby:2.4.3
 # Dependencies for developing and running Backup
 #  * The Nokogiri gem requires libxml2
 #  * The unf_ext gem requires the g++ compiler to build
-ENV APP_DEPS bsdtar ca-certificates curl g++ git \
-    libxml2 libxslt1.1 libyaml-0-2 openssl
+ENV APP_DEPS ca-certificates curl g++ git \
+    libarchive-tools libxml2 libxslt1.1 libyaml-0-2 openssl
 
 RUN apt-get update && apt-get install -y --no-install-recommends $APP_DEPS
 

--- a/backup.gemspec
+++ b/backup.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "excon", "~> 0.71"
   gem.add_dependency "unf", "0.1.3" # for fog/AWS
   gem.add_dependency "dropbox-sdk", "1.6.5"
-  gem.add_dependency "net-ssh", "5.2.0"
-  gem.add_dependency "net-scp", "~> 2.0.0"
+  gem.add_dependency "net-ssh", "7.1.0"
+  gem.add_dependency "net-scp", "~> 4.0.0"
   gem.add_dependency "net-sftp", "2.1.2"
   gem.add_dependency "net-ftp", "~> 0.1.3"
   gem.add_dependency "net-smtp", "~> 0.1"


### PR DESCRIPTION
On Ubuntu 22.04 with OpenSSL 3.0 backup failed to send files over ssh using rsa keys with error:
```
[2023/03/17 22:41:33][error] --- Wrapped Exception ---
[2023/03/17 22:41:33][error] OpenSSL::PKey::PKeyError: rsa#set_key= is incompatible with OpenSSL 3.0
[2023/03/17 22:41:33][error] 
[2023/03/17 22:41:33][error] Backtrace:
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/buffer.rb:317:in `set_key'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/buffer.rb:317:in `read_keyblob'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/buffer.rb:249:in `read_key'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/known_hosts.rb:154:in `block (2 levels) in keys_for'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/known_hosts.rb:134:in `each_line'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/known_hosts.rb:134:in `block in keys_for'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/known_hosts.rb:132:in `open'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/known_hosts.rb:132:in `keys_for'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/known_hosts.rb:64:in `block in search_in'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/known_hosts.rb:64:in `each'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/known_hosts.rb:64:in `flat_map'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/known_hosts.rb:64:in `search_in'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/known_hosts.rb:58:in `search_for'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/session.rb:98:in `host_keys'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/algorithms.rb:257:in `prepare_preferred_algorithms!'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/algorithms.rb:137:in `initialize'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/session.rb:88:in `new'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh/transport/session.rb:88:in `initialize'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh.rb:246:in `new'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-ssh-5.2.0/lib/net/ssh.rb:246:in `start'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/net-sftp-2.1.2/lib/net/sftp.rb:31:in `start'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/backup-5.1.0.pre.iiet/lib/backup/storage/sftp.rb:28:in `connection'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/backup-5.1.0.pre.iiet/lib/backup/storage/sftp.rb:34:in `transfer!'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/backup-5.1.0.pre.iiet/lib/backup/storage/base.rb:43:in `perform!'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/backup-5.1.0.pre.iiet/lib/backup/model.rb:329:in `block in store!'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/backup-5.1.0.pre.iiet/lib/backup/model.rb:327:in `map'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/backup-5.1.0.pre.iiet/lib/backup/model.rb:327:in `store!'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/backup-5.1.0.pre.iiet/lib/backup/model.rb:301:in `block in procedures'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/backup-5.1.0.pre.iiet/lib/backup/model.rb:267:in `block in perform!'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/backup-5.1.0.pre.iiet/lib/backup/model.rb:266:in `each'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/backup-5.1.0.pre.iiet/lib/backup/model.rb:266:in `perform!'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/backup-5.1.0.pre.iiet/lib/backup/cli.rb:155:in `perform'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
[2023/03/17 22:41:33][error]   /var/lib/gems/3.0.0/gems/backup-5.1.0.pre.iiet/bin/backup:5:in `<top (required)>'
[2023/03/17 22:41:33][error]   /usr/local/bin/backup:25:in `load'
[2023/03/17 22:41:33][error]   /usr/local/bin/backup:25:in `<main>'
```
Running system:
```
$ cat /etc/os-release 
PRETTY_NAME="Ubuntu 22.04.2 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.2 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
$ openssl version
OpenSSL 3.0.2 15 Mar 2022 (Library: OpenSSL 3.0.2 15 Mar 2022)
$ ruby --version
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux-gnu]
```
After changes, files were sent to remote host successfully.