### PR TITLE
Moving mysql password to env variable

### DIFF
--- a/lib/backup/database/mysql.rb
+++ b/lib/backup/database/mysql.rb
@@ -101,15 +101,19 @@ module Backup
       private
 
       def mysqldump
-        "#{utility(:mysqldump)} #{user_options} #{credential_options} " \
+        "#{password_env}#{utility(:mysqldump)} #{user_options} #{credential_options} " \
           "#{connectivity_options} #{name_option} " \
           "#{tables_to_dump} #{tables_to_skip}"
+      end
+
+      def password_env
+        "MYSQL_PWD=#{Shellwords.escape(password)} " if password
       end
 
       def credential_options
         opts = []
         opts << "--user=#{Shellwords.escape(username)}" if username
-        opts << "--password=#{Shellwords.escape(password)}" if password
+        opts << "--password=#{Shellwords.escape(password)}" if password && backup_engine.to_sym != :mysqldump
         opts.join(" ")
       end
 

--- a/spec/database/mysql_spec.rb
+++ b/spec/database/mysql_spec.rb
@@ -251,7 +251,7 @@ module Backup
         )
       end
 
-      it 'adds password env' do
+      it "adds password env" do
         db.password = "my_password"
         expect(db.send(:mysqldump)).to start_with(
           "MYSQL_PWD=my_password mysqldump"
@@ -305,7 +305,6 @@ module Backup
             "MYSQL_PWD=my_password\\'\\\" "
           )
         end
-
       end # describe '#password_env'
 
       describe "#connectivity_options" do

--- a/spec/database/mysql_spec.rb
+++ b/spec/database/mysql_spec.rb
@@ -250,6 +250,13 @@ module Backup
           "mysqldump #{" " * (option_methods.count - 1)}"
         )
       end
+
+      it 'adds password env' do
+        db.password = "my_password"
+        expect(db.send(:mysqldump)).to start_with(
+          "MYSQL_PWD=my_password mysqldump"
+        )
+      end
     end # describe '#mysqldump'
 
     describe "backup engine option methods" do
@@ -264,12 +271,12 @@ module Backup
 
           db.password = "my_password"
           expect(db.send(:credential_options)).to eq(
-            "--user=my_user --password=my_password"
+            "--user=my_user"
           )
 
           db.username = nil
           expect(db.send(:credential_options)).to eq(
-            "--password=my_password"
+            ""
           )
         end
 
@@ -277,10 +284,29 @@ module Backup
           db.username = "my_user'\""
           db.password = "my_password'\""
           expect(db.send(:credential_options)).to eq(
-            "--user=my_user\\'\\\" --password=my_password\\'\\\""
+            "--user=my_user\\'\\\""
           )
         end
       end # describe '#credential_options'
+
+      describe "#password_env" do
+        it "returns the envs" do
+          db.password = "my_password"
+
+          expect(db.send(:password_env)).to eq(
+            "MYSQL_PWD=my_password "
+          )
+        end
+
+        it "handles special characters" do
+          db.password = "my_password'\""
+
+          expect(db.send(:password_env)).to eq(
+            "MYSQL_PWD=my_password\\'\\\" "
+          )
+        end
+
+      end # describe '#password_env'
 
       describe "#connectivity_options" do
         it "returns only the socket argument if #socket specified" do


### PR DESCRIPTION
Moving mysql password to MYSQL_PWD variable.
It allows increase security level and prevent warning about cli password: `mysqldump: [Warning] Using a password on the command line interface can be insecure.`

