### PR TITLE
Relax nokogiri dependency

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "dogapi", "1.40.0"
   gem.add_dependency "aws-sdk", "~> 2"
   gem.add_dependency "qiniu", "~> 6.5"
-  gem.add_dependency "nokogiri", "~> 1.11.7"
+  gem.add_dependency "nokogiri", "~> 1.11"
   gem.add_dependency "activesupport", "~> 5.2.8"
 
   gem.add_development_dependency "rubocop", "0.48.1"


### PR DESCRIPTION
Tested with ruby `2.7.8 + nokogiri 1.15.7` and `ruby 3.3.5 + nokogiri 1.18.3`

Test are green and the it works (at least on my machine 😁 )